### PR TITLE
Add CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,11 @@
+machine:
+  ruby:
+    version: 2.3.3
+  node:
+    version: 6.9.0
+  environment:
+    PATH: "${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin"
+
+test:
+  pre:
+    - bundle exec rubocop


### PR DESCRIPTION
Adds a ~~`.travis.yml` file for the two Ruby versions this library is currently being used with~~ `circle.yml` file for Ruby 2.3.3.