### PR TITLE
Handle all exceptions in forked process

### DIFF
--- a/lib/bump/shared_helpers.rb
+++ b/lib/bump/shared_helpers.rb
@@ -34,7 +34,7 @@ module Bump
         begin
           read.close
           result = yield
-        rescue => error
+        rescue Exception => error # rubocop:disable Lint/RescueException
           result = { _error_details: { error_class: error.class.to_s,
                                        error_message: error.message } }
         ensure

--- a/spec/shared_helpers_spec.rb
+++ b/spec/shared_helpers_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Bump::SharedHelpers do
     end
 
     context "when the forked process raises an error" do
-      let(:task) { -> { raise "hell" } }
+      let(:task) { -> { raise Exception, "hell" } }
 
       it "raises a ChildProcessFailed error" do
         expect { run_sub_process }.


### PR DESCRIPTION
Doing `rescue => err` only rescues exceptions that inherit from `StandardError` and misses those that inherit directly from `Exception`. Annoyingly, WebMock's "oi you made an HTTP request you shouldn't have" exception inherits directly from `Exception` [source][webmock-grr], so
will be missed by a regular old `rescue => err`.

Generally, it's bad form to rescue all errors descended from `Exception`, but here we're killing the process immediately, and really do want to tell the parent about _anything_ that went wrong, so it's ok.

[webmock-grr]: https://github.com/bblimke/webmock/blob/a4aad22adc622699a8ea14c70d04acef8f67a512/lib/webmock/errors.rb#L3