### PR TITLE
Ignore Ruby version specified in Gemfile

### DIFF
--- a/spec/dependency_file_updaters/ruby_spec.rb
+++ b/spec/dependency_file_updaters/ruby_spec.rb
@@ -100,6 +100,14 @@ RSpec.describe Bump::DependencyFileUpdaters::Ruby do
       end
     end
 
+    context "when the Gemfile specifies a Ruby version" do
+      let(:gemfile_body) { fixture("ruby", "gemfiles", "explicit_ruby") }
+
+      it "locks the updated gem to the latest version" do
+        expect(file.content).to include "business (1.5.0)"
+      end
+    end
+
     context "when the old Gemfile didn't specify the version" do
       let(:gemfile_body) do
         fixture("ruby", "gemfiles", "version_not_specified")

--- a/spec/fixtures/ruby/gemfiles/explicit_ruby
+++ b/spec/fixtures/ruby/gemfiles/explicit_ruby
@@ -1,0 +1,5 @@
+ruby "2.2.0"
+source "https://rubygems.org"
+
+gem "business", "~> 1.4.0"
+gem "statesman", "~> 1.2.0"

--- a/spec/update_checkers/ruby_spec.rb
+++ b/spec/update_checkers/ruby_spec.rb
@@ -18,9 +18,7 @@ RSpec.describe Bump::UpdateCheckers::Ruby do
   let(:dependency) { Bump::Dependency.new(name: "business", version: "1.3") }
 
   let(:gemfile) do
-    Bump::DependencyFile.new(
-      content: fixture("ruby", "gemfiles", "Gemfile"), name: "Gemfile"
-    )
+    Bump::DependencyFile.new(content: gemfile_content, name: "Gemfile")
   end
   let(:gemfile_lock) do
     Bump::DependencyFile.new(
@@ -28,6 +26,7 @@ RSpec.describe Bump::UpdateCheckers::Ruby do
       name: "Gemfile.lock"
     )
   end
+  let(:gemfile_content) { fixture("ruby", "gemfiles", "Gemfile") }
   let(:gemfile_lock_content) { fixture("ruby", "lockfiles", "Gemfile.lock") }
 
   describe "#needs_update?" do
@@ -35,6 +34,11 @@ RSpec.describe Bump::UpdateCheckers::Ruby do
 
     context "given an outdated dependency" do
       it { is_expected.to be_truthy }
+
+      context "with a Gemfile that specifies a Ruby version" do
+        let(:gemfile_content) { fixture("ruby", "gemfiles", "explicit_ruby") }
+        it { is_expected.to be_truthy }
+      end
     end
 
     context "given an up-to-date dependency" do


### PR DESCRIPTION
Ignore any explicit Ruby version specified in a Gemfile, as a mismatch with the
system Ruby version that Bump is running on causes an error during dependency
resolution.

Ideally we would run the DependencyFileUpdaters::Ruby class using whichever
Ruby version was specified in the Gemfile (or in the .ruby_version file, which
we're not even fetching at the moment...), but that's impractical, and it's
better to produce a PR for the user with gems that require a bump to their
Ruby version (and will blow up in CI) than not to produce a PR at all.