### PR TITLE
Handle 404s for Rubygems when creating PRs

### DIFF
--- a/lib/bump/dependency_metadata_finders/ruby.rb
+++ b/lib/bump/dependency_metadata_finders/ruby.rb
@@ -26,6 +26,10 @@ module Bump
                      find { |url| url =~ GITHUB_REGEX }
 
         @github_repo = source_url.match(GITHUB_REGEX)[:repo] if source_url
+      rescue JSON::ParserError
+        # Replace with Gems::NotFound error if/when
+        # https://github.com/rubygems/gems/pull/38 is merged.
+        @github_repo = nil
       end
     end
   end

--- a/spec/dependency_metadata_finders/ruby_spec.rb
+++ b/spec/dependency_metadata_finders/ruby_spec.rb
@@ -21,10 +21,11 @@ RSpec.describe Bump::DependencyMetadataFinders::Ruby do
   describe "#github_repo" do
     subject(:github_repo) { finder.github_repo }
     let(:rubygems_url) { "https://rubygems.org/api/v1/gems/business.json" }
+    let(:rubygems_response_code) { 200 }
 
     before do
       stub_request(:get, rubygems_url).
-        to_return(status: 200, body: rubygems_response)
+        to_return(status: rubygems_response_code, body: rubygems_response)
     end
 
     context "when there is a github link in the rubygems response" do
@@ -55,6 +56,13 @@ RSpec.describe Bump::DependencyMetadataFinders::Ruby do
         2.times { github_repo }
         expect(WebMock).to have_requested(:get, rubygems_url).once
       end
+    end
+
+    context "when the gem isn't on Rubygems" do
+      let(:rubygems_response_code) { 404 }
+      let(:rubygems_response) { "This rubygem could not be found." }
+
+      it { is_expected.to be_nil }
     end
   end
 end


### PR DESCRIPTION
Happens when the gem was fetched from a source other than Rubygems.

Would be nice to pass the source around along with the dependency, so this class can lookup from sources other than Rubygems. Even if we do that we should make this lookup robust, though.