### PR TITLE
Raise a Bump::DependencyFileNotFound error if files can't be found

### DIFF
--- a/lib/bump/dependency_file_fetchers/base.rb
+++ b/lib/bump/dependency_file_fetchers/base.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require "bump/dependency_file"
+require "bump/errors"
 
 module Bump
   module DependencyFileFetchers
@@ -25,6 +26,8 @@ module Bump
       def fetch_file_from_github(file_name)
         content = github_client.contents(repo.name, path: file_name).content
         DependencyFile.new(name: file_name, content: Base64.decode64(content))
+      rescue Octokit::NotFound
+        raise Bump::DependencyFileNotFound
       end
     end
   end

--- a/lib/bump/dependency_file_fetchers/base.rb
+++ b/lib/bump/dependency_file_fetchers/base.rb
@@ -27,7 +27,7 @@ module Bump
         content = github_client.contents(repo.name, path: file_name).content
         DependencyFile.new(name: file_name, content: Base64.decode64(content))
       rescue Octokit::NotFound
-        raise Bump::DependencyFileNotFound
+        raise Bump::DependencyFileNotFound, file_name
       end
     end
   end

--- a/lib/bump/errors.rb
+++ b/lib/bump/errors.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Bump
+  class BumpError < StandardError; end
+  class DependencyFileNotFound < BumpError; end
+end

--- a/lib/bump/errors.rb
+++ b/lib/bump/errors.rb
@@ -2,5 +2,13 @@
 
 module Bump
   class BumpError < StandardError; end
-  class DependencyFileNotFound < BumpError; end
+
+  class DependencyFileNotFound < BumpError
+    attr_reader :file_name
+
+    def initialize(file_name, msg = nil)
+      @file_name = file_name
+      super(msg)
+    end
+  end
 end

--- a/spec/dependency_file_fetchers/ruby_spec.rb
+++ b/spec/dependency_file_fetchers/ruby_spec.rb
@@ -42,5 +42,14 @@ RSpec.describe Bump::DependencyFileFetchers::Ruby do
       it { is_expected.to be_a(Bump::DependencyFile) }
       its(:content) { is_expected.to include("octokit") }
     end
+
+    context "when a dependency file can't be found" do
+      before { stub_request(:get, url + "Gemfile").to_return(status: 404) }
+
+      it "raises a custom error" do
+        expect { file_fetcher.files }.
+          to raise_error(Bump::DependencyFileNotFound)
+      end
+    end
   end
 end

--- a/spec/dependency_file_fetchers/ruby_spec.rb
+++ b/spec/dependency_file_fetchers/ruby_spec.rb
@@ -48,7 +48,9 @@ RSpec.describe Bump::DependencyFileFetchers::Ruby do
 
       it "raises a custom error" do
         expect { file_fetcher.files }.
-          to raise_error(Bump::DependencyFileNotFound)
+          to raise_error(Bump::DependencyFileNotFound) do |error|
+            expect(error.file_name).to eq("Gemfile")
+          end
       end
     end
   end


### PR DESCRIPTION
Saves us from having to rescue `Octokit::NotFound` in consumers of the gem.

Would be nice to extend the error to include details of the file path that wasn't found, but I'm on a train and can't remember how to fiddle with error initializers. Can be done in a separate PR...