### PR TITLE
Add DependencyFileNotEvaluatable error

### DIFF
--- a/lib/bump/errors.rb
+++ b/lib/bump/errors.rb
@@ -3,6 +3,8 @@
 module Bump
   class BumpError < StandardError; end
 
+  class DependencyFileNotEvaluatable < BumpError; end
+
   class DependencyFileNotFound < BumpError
     attr_reader :file_name
 

--- a/lib/bump/update_checkers/ruby.rb
+++ b/lib/bump/update_checkers/ruby.rb
@@ -2,6 +2,7 @@
 require "gems"
 require "bump/update_checkers/base"
 require "bump/shared_helpers"
+require "bump/errors"
 
 module Bump
   module UpdateCheckers
@@ -73,6 +74,11 @@ module Bump
                 source
             end
           end
+      rescue Bump::SharedHelpers::ChildProcessFailed => err
+        raise unless err.error_class == "Bundler::Dsl::DSLError"
+
+        msg = err.error_class + " with message: " + err.error_message
+        raise Bump::DependencyFileNotEvaluatable, msg
       end
 
       def gemfile_lock

--- a/spec/fixtures/ruby/gemfiles/includes_requires
+++ b/spec/fixtures/ruby/gemfiles/includes_requires
@@ -1,0 +1,5 @@
+source 'http://rubygems.org'
+
+%w[cli dependency].each do |path|
+  require File.expand_path("../lib/backup/#{path}", __FILE__)
+end

--- a/spec/update_checkers/ruby_spec.rb
+++ b/spec/update_checkers/ruby_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Bump::UpdateCheckers::Ruby do
     subject { checker.latest_version }
     it { is_expected.to eq("1.5.0") }
 
-    context "given a lockfile with a non-rubygems source" do
+    context "given a Gemfile with a non-rubygems source" do
       let(:gemfile_lock_content) do
         fixture("ruby", "lockfiles", "specified_source.lock")
       end
@@ -103,6 +103,20 @@ RSpec.describe Bump::UpdateCheckers::Ruby do
       end
 
       it { is_expected.to eq("1.9.0") }
+    end
+
+    context "given an unreadable Gemfile" do
+      let(:gemfile) do
+        Bump::DependencyFile.new(
+          content: fixture("ruby", "gemfiles", "includes_requires"),
+          name: "Gemfile"
+        )
+      end
+
+      it "blows up with a useful error" do
+        expect { checker.latest_version }.
+          to raise_error(Bump::DependencyFileNotEvaluatable)
+      end
     end
   end
 end


### PR DESCRIPTION
If Bundler can't parse the Gemfile we've given it we may want to catch the error and notify the user. Giving such cases their own error class should help with that.