### PR TITLE
Stop updating RUBY_VERSION and BUNDLED_WITH details in Ruby lockfiles

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,9 @@ AllCops:
     - vendor/**/*
     - bin/**/*
 
+Metrics/ClassLength:
+  Max: 150
+
 Metrics/LineLength:
   Max: 80
 

--- a/spec/fixtures/ruby/lockfiles/explicit_ruby.lock
+++ b/spec/fixtures/ruby/lockfiles/explicit_ruby.lock
@@ -1,0 +1,18 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    business (1.4.0)
+    statesman (1.2.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  business (~> 1.4.0)
+  statesman (~> 1.2.0)
+
+RUBY VERSION
+   ruby 2.2.0p0
+
+BUNDLED WITH
+   1.14.6

--- a/spec/fixtures/ruby/lockfiles/no_bundled_with.lock
+++ b/spec/fixtures/ruby/lockfiles/no_bundled_with.lock
@@ -1,0 +1,12 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    business (1.4.0)
+    statesman (1.2.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  business (~> 1.4.0)
+  statesman (~> 1.2.0)


### PR DESCRIPTION
Previously, we were nobbling both. Now we won't nobble either.