### PR TITLE
Handle public git sources gracefully, and error specifically for private ones

### DIFF
--- a/lib/bump/dependency_file_updaters/ruby.rb
+++ b/lib/bump/dependency_file_updaters/ruby.rb
@@ -4,6 +4,7 @@ require "bundler"
 require "bump/dependency_file"
 require "bump/shared_helpers"
 require "bump/dependency_file_updaters/errors"
+require "bump/errors"
 
 module Bump
   module DependencyFileUpdaters
@@ -78,6 +79,9 @@ module Bump
       end
 
       def build_updated_gemfile_lock
+        previous_stderr = $stderr
+        $stderr = StringIO.new
+
         lockfile_body =
           SharedHelpers.in_a_temporary_directory do |dir|
             write_temporary_dependency_files_to(dir)
@@ -94,9 +98,20 @@ module Bump
           end
         post_process_lockfile(lockfile_body)
       rescue SharedHelpers::ChildProcessFailed => error
-        raise unless error.error_class == "Bundler::VersionConflict"
+        handle_bundler_errors(error)
+      ensure
+        $stderr = previous_stderr
+      end
 
-        raise DependencyFileUpdaters::VersionConflict
+      def handle_bundler_errors(error)
+        case error.error_class
+        when "Bundler::VersionConflict"
+          raise DependencyFileUpdaters::VersionConflict
+        when "Bundler::Source::Git::GitCommandError"
+          raise Bump::GitDependencyNotFound
+        else
+          raise
+        end
       end
 
       def write_temporary_dependency_files_to(dir)

--- a/lib/bump/dependency_file_updaters/ruby.rb
+++ b/lib/bump/dependency_file_updaters/ruby.rb
@@ -79,9 +79,6 @@ module Bump
       end
 
       def build_updated_gemfile_lock
-        previous_stderr = $stderr
-        $stderr = StringIO.new
-
         lockfile_body =
           SharedHelpers.in_a_temporary_directory do |dir|
             write_temporary_dependency_files_to(dir)
@@ -99,8 +96,6 @@ module Bump
         post_process_lockfile(lockfile_body)
       rescue SharedHelpers::ChildProcessFailed => error
         handle_bundler_errors(error)
-      ensure
-        $stderr = previous_stderr
       end
 
       def handle_bundler_errors(error)

--- a/lib/bump/dependency_file_updaters/ruby.rb
+++ b/lib/bump/dependency_file_updaters/ruby.rb
@@ -103,7 +103,7 @@ module Bump
         when "Bundler::VersionConflict"
           raise DependencyFileUpdaters::VersionConflict
         when "Bundler::Source::Git::GitCommandError"
-          raise Bump::GitDependencyNotFound
+          raise Bump::GitCommandError
         else
           raise
         end

--- a/lib/bump/errors.rb
+++ b/lib/bump/errors.rb
@@ -12,5 +12,5 @@ module Bump
     end
   end
 
-  class GitDependencyNotFound < BumpError; end
+  class GitCommandError < BumpError; end
 end

--- a/lib/bump/errors.rb
+++ b/lib/bump/errors.rb
@@ -11,4 +11,6 @@ module Bump
       super(msg)
     end
   end
+
+  class GitDependencyNotFound < BumpError; end
 end

--- a/lib/bump/update_checkers/ruby.rb
+++ b/lib/bump/update_checkers/ruby.rb
@@ -31,7 +31,7 @@ module Bump
       private
 
       def fetch_latest_version
-        # If this dependency doesn't have a source specified we use the detault
+        # If this dependency doesn't have a source specified we use the default
         # one, which is Rubygems.
         return Gems.info(dependency.name)["version"] if gem_source.nil?
 

--- a/lib/bump/update_checkers/ruby.rb
+++ b/lib/bump/update_checkers/ruby.rb
@@ -31,14 +31,17 @@ module Bump
       private
 
       def fetch_latest_version
-        # If this dependency doesn't have a source specified we can just use
-        # Rubygems to get the latest version.
-        return Gems.info(dependency.name)["version"] if gem_remotes.none?
+        # If this dependency doesn't have a source specified we use the detault
+        # one, which is Rubygems.
+        return Gems.info(dependency.name)["version"] if gem_source.nil?
 
-        # Otherwise, we need to look at the versions in each of the specified
-        # sources. To start with, get an array of Bundler::Dependency::Fetchers
-        # for the remotes we need to look for this dependency at.
-        gem_source = Bundler::Source::Rubygems.new("remotes" => gem_remotes)
+        # Otherwise, if the source is anything other than a Rubygems server
+        # we just return `nil` and ignore the gem. This happens in the case of
+        # a `git` or `path` source.
+        return unless gem_source.is_a?(Bundler::Source::Rubygems)
+
+        # Finally, when the source is a Rubygems server we piggyback off Bundler
+        # to get the latest version.
         gem_fetchers =
           gem_source.fetchers.flat_map(&:fetchers).
           select { |f| f.is_a?(Bundler::Fetcher::Dependency) }
@@ -53,8 +56,8 @@ module Bump
         versions.reject(&:prerelease?).sort.last.version
       end
 
-      def gem_remotes
-        @gem_remotes ||=
+      def gem_source
+        @gem_source ||=
           SharedHelpers.in_a_temporary_directory do |dir|
             write_temporary_dependency_files_to(dir)
 
@@ -65,12 +68,9 @@ module Bump
                 nil
               )
 
-              remotes =
-                definition.dependencies.
+              definition.dependencies.
                 find { |dep| dep.name == dependency.name }.
-                source&.options&.fetch("remotes")
-
-              remotes || []
+                source
             end
           end
       end

--- a/spec/dependency_file_updaters/ruby_spec.rb
+++ b/spec/dependency_file_updaters/ruby_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe Bump::DependencyFileUpdaters::Ruby do
 
         it "raises a helpful error" do
           expect { updater.updated_gemfile_lock }.
-            to raise_error(Bump::GitDependencyNotFound)
+            to raise_error(Bump::GitCommandError)
         end
       end
     end

--- a/spec/dependency_file_updaters/ruby_spec.rb
+++ b/spec/dependency_file_updaters/ruby_spec.rb
@@ -179,6 +179,7 @@ RSpec.describe Bump::DependencyFileUpdaters::Ruby do
 
       context "that is private" do
         let(:gemfile_body) { fixture("ruby", "gemfiles", "private_git_source") }
+        around { |example| capture_stderr { example.run } }
 
         it "raises a helpful error" do
           expect { updater.updated_gemfile_lock }.

--- a/spec/dependency_file_updaters/ruby_spec.rb
+++ b/spec/dependency_file_updaters/ruby_spec.rb
@@ -170,6 +170,23 @@ RSpec.describe Bump::DependencyFileUpdaters::Ruby do
       end
     end
 
+    context "when another gem in the Gemfile has a git source" do
+      let(:gemfile_body) { fixture("ruby", "gemfiles", "git_source") }
+
+      it "updates the gem just fine" do
+        expect(file.content).to include "business (1.5.0)"
+      end
+
+      context "that is private" do
+        let(:gemfile_body) { fixture("ruby", "gemfiles", "private_git_source") }
+
+        it "raises a helpful error" do
+          expect { updater.updated_gemfile_lock }.
+            to raise_error(Bump::GitDependencyNotFound)
+        end
+      end
+    end
+
     context "when there is a version conflict" do
       let(:gemfile_body) { fixture("ruby", "gemfiles", "version_conflict") }
       let(:dependency) do

--- a/spec/fixtures/ruby/gemfiles/git_source
+++ b/spec/fixtures/ruby/gemfiles/git_source
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gem "business", "~> 1.4.0"
+gem "statesman", "~> 1.2.0"
+gem "prius", git: "https://github.com/gocardless/prius"

--- a/spec/fixtures/ruby/gemfiles/private_git_source
+++ b/spec/fixtures/ruby/gemfiles/private_git_source
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gem "business", "~> 1.4.0"
+gem "statesman", "~> 1.2.0"
+gem "prius", git: "https://github.com/fundingcircle/prius"

--- a/spec/fixtures/ruby/lockfiles/git_source.lock
+++ b/spec/fixtures/ruby/lockfiles/git_source.lock
@@ -1,0 +1,22 @@
+GIT
+  remote: https://github.com/gocardless/prius
+  revision: cff701b3bfb182afc99a85657d7c9f3d6c1ccce2
+  specs:
+    prius (1.0.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    business (1.4.0)
+    statesman (1.2.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  business (~> 1.4.0)
+  prius!
+  statesman (~> 1.2.0)
+
+BUNDLED WITH
+   1.14.6

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,3 +18,11 @@ end
 def fixture(*name)
   File.read(File.join("spec", "fixtures", File.join(*name)))
 end
+
+def capture_stderr
+  previous_stderr = $stderr
+  $stderr = StringIO.new
+  yield
+ensure
+  $stderr = previous_stderr
+end

--- a/spec/update_checkers/ruby_spec.rb
+++ b/spec/update_checkers/ruby_spec.rb
@@ -72,6 +72,16 @@ RSpec.describe Bump::UpdateCheckers::Ruby do
 
       it { is_expected.to be_truthy }
     end
+
+    context "given a git source" do
+      let(:gemfile_lock_content) do
+        fixture("ruby", "lockfiles", "git_source.lock")
+      end
+      let(:gemfile_content) { fixture("ruby", "gemfiles", "git_source") }
+      let(:dependency) { Bump::Dependency.new(name: "prius", version: "0.9") }
+
+      it { is_expected.to be_falsey }
+    end
   end
 
   describe "#latest_version" do
@@ -82,12 +92,7 @@ RSpec.describe Bump::UpdateCheckers::Ruby do
       let(:gemfile_lock_content) do
         fixture("ruby", "lockfiles", "specified_source.lock")
       end
-      let(:gemfile) do
-        Bump::DependencyFile.new(
-          content: fixture("ruby", "gemfiles", "specified_source"),
-          name: "Gemfile"
-        )
-      end
+      let(:gemfile_content) { fixture("ruby", "gemfiles", "specified_source") }
       let(:gemfury_business_url) do
         "https://repo.fury.io/greysteil/api/v1/dependencies?gems=business"
       end


### PR DESCRIPTION
The recent changes to `UpdateChecker` have broken `bump-core` for Ruby gemfiles with `git` references in them. This PR fixes that, and also improves the error messaging from `DependencyFileUpdater` when a repo is private. That error messaging will need further improvements, but in time will allow us to tell an integrator which repos they need to give Bump / Dependabot access to.