### PR TITLE
Rename Bump::DependencyFileUpdaters::VersionConflict to Bump::VersionConflict

### DIFF
--- a/lib/bump/dependency_file_updaters/errors.rb
+++ b/lib/bump/dependency_file_updaters/errors.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-module Bump
-  module DependencyFileUpdaters
-    class VersionConflict < StandardError; end
-  end
-end

--- a/lib/bump/dependency_file_updaters/ruby.rb
+++ b/lib/bump/dependency_file_updaters/ruby.rb
@@ -3,7 +3,6 @@ require "gemnasium/parser"
 require "bundler"
 require "bump/dependency_file"
 require "bump/shared_helpers"
-require "bump/dependency_file_updaters/errors"
 require "bump/errors"
 
 module Bump
@@ -101,7 +100,7 @@ module Bump
       def handle_bundler_errors(error)
         case error.error_class
         when "Bundler::VersionConflict"
-          raise DependencyFileUpdaters::VersionConflict
+          raise Bump::VersionConflict
         when "Bundler::Source::Git::GitCommandError"
           raise Bump::GitCommandError
         else

--- a/lib/bump/errors.rb
+++ b/lib/bump/errors.rb
@@ -3,6 +3,8 @@
 module Bump
   class BumpError < StandardError; end
 
+  class VersionConflict < BumpError; end
+  class GitCommandError < BumpError; end
   class DependencyFileNotEvaluatable < BumpError; end
 
   class DependencyFileNotFound < BumpError
@@ -13,6 +15,4 @@ module Bump
       super(msg)
     end
   end
-
-  class GitCommandError < BumpError; end
 end

--- a/spec/dependency_file_updaters/ruby_spec.rb
+++ b/spec/dependency_file_updaters/ruby_spec.rb
@@ -207,9 +207,9 @@ RSpec.describe Bump::DependencyFileUpdaters::Ruby do
           to_return(status: 200, body: fixture("rubygems-dependencies-i18n"))
       end
 
-      it "raises a DependencyFileUpdaters::VersionConflict error" do
+      it "raises a Bump::VersionConflict error" do
         expect { updater.updated_gemfile_lock }.
-          to raise_error(Bump::DependencyFileUpdaters::VersionConflict)
+          to raise_error(Bump::VersionConflict)
       end
     end
   end


### PR DESCRIPTION
Better fit with existing errors.