### PR TITLE
Store the failed git command on GitCommandError

### DIFF
--- a/lib/bump/dependency_file_updaters/ruby.rb
+++ b/lib/bump/dependency_file_updaters/ruby.rb
@@ -11,6 +11,7 @@ module Bump
       attr_reader :gemfile, :gemfile_lock, :dependency, :github_access_token
 
       LOCKFILE_ENDING = /(?<ending>\s*(?:RUBY VERSION|BUNDLED WITH).*)/m
+      GIT_COMMAND_ERROR_REGEX = /`(?<command>.*)`/
 
       def initialize(dependency_files:, dependency:, github_access_token:)
         @gemfile = dependency_files.find { |f| f.name == "Gemfile" }
@@ -102,7 +103,8 @@ module Bump
         when "Bundler::VersionConflict"
           raise Bump::VersionConflict
         when "Bundler::Source::Git::GitCommandError"
-          raise Bump::GitCommandError
+          command = error.message.match(GIT_COMMAND_ERROR_REGEX)[:command]
+          raise Bump::GitCommandError, command
         else
           raise
         end

--- a/lib/bump/errors.rb
+++ b/lib/bump/errors.rb
@@ -4,7 +4,6 @@ module Bump
   class BumpError < StandardError; end
 
   class VersionConflict < BumpError; end
-  class GitCommandError < BumpError; end
   class DependencyFileNotEvaluatable < BumpError; end
 
   class DependencyFileNotFound < BumpError
@@ -12,6 +11,15 @@ module Bump
 
     def initialize(file_name, msg = nil)
       @file_name = file_name
+      super(msg)
+    end
+  end
+
+  class GitCommandError < BumpError
+    attr_reader :command
+
+    def initialize(command, msg = nil)
+      @command = command
       super(msg)
     end
   end

--- a/spec/dependency_file_updaters/ruby_spec.rb
+++ b/spec/dependency_file_updaters/ruby_spec.rb
@@ -183,7 +183,10 @@ RSpec.describe Bump::DependencyFileUpdaters::Ruby do
 
         it "raises a helpful error" do
           expect { updater.updated_gemfile_lock }.
-            to raise_error(Bump::GitCommandError)
+            to raise_error do |error|
+              expect(error).to be_a(Bump::GitCommandError)
+              expect(error.command).to start_with("git clone 'https://github")
+            end
         end
       end
     end


### PR DESCRIPTION
Will allow us to get details of which repo we couldn't reach in whatever application rescues these errors.