### PR TITLE
Support fetching dependency files from a specified directory

### DIFF
--- a/lib/bump/dependency_file.rb
+++ b/lib/bump/dependency_file.rb
@@ -1,15 +1,27 @@
 # frozen_string_literal: true
 module Bump
   class DependencyFile
-    attr_reader :name, :content
+    attr_reader :name, :content, :directory
 
-    def initialize(name:, content:)
+    def initialize(name:, content:, directory: "/")
       @name = name
       @content = content
+      @directory = clean_directory(directory)
     end
 
     def to_h
-      { "name" => name, "content" => content }
+      { "name" => name, "content" => content, "directory" => directory }
+    end
+
+    def path
+      File.join(directory, name)
+    end
+
+    private
+
+    def clean_directory(directory)
+      # Directory should always start with a `/`
+      directory.sub(%r{^/*}, "/")
     end
   end
 end

--- a/lib/bump/dependency_file_fetchers/base.rb
+++ b/lib/bump/dependency_file_fetchers/base.rb
@@ -5,11 +5,12 @@ require "bump/errors"
 module Bump
   module DependencyFileFetchers
     class Base
-      attr_reader :repo, :github_client
+      attr_reader :repo, :github_client, :directory
 
-      def initialize(repo:, github_client:)
+      def initialize(repo:, github_client:, directory: "/")
         @repo = repo
         @github_client = github_client
+        @directory = directory
       end
 
       def files
@@ -24,10 +25,16 @@ module Bump
       private
 
       def fetch_file_from_github(file_name)
-        content = github_client.contents(repo.name, path: file_name).content
-        DependencyFile.new(name: file_name, content: Base64.decode64(content))
+        file_path = File.join(directory, file_name)
+        content = github_client.contents(repo.name, path: file_path).content
+
+        DependencyFile.new(
+          name: file_name,
+          content: Base64.decode64(content),
+          directory: directory
+        )
       rescue Octokit::NotFound
-        raise Bump::DependencyFileNotFound, file_name
+        raise Bump::DependencyFileNotFound, file_path
       end
     end
   end

--- a/lib/bump/errors.rb
+++ b/lib/bump/errors.rb
@@ -7,11 +7,20 @@ module Bump
   class DependencyFileNotEvaluatable < BumpError; end
 
   class DependencyFileNotFound < BumpError
-    attr_reader :file_name
+    attr_reader :file_path
 
-    def initialize(file_name, msg = nil)
-      @file_name = file_name
+    def initialize(file_path, msg = nil)
+      @file_path = file_path
       super(msg)
+    end
+
+    def file_name
+      file_path.split("/").last
+    end
+
+    def directory
+      # Directory should always start with a `/`
+      file_path.split("/")[0..-2].join("/").sub(%r{^/*}, "/")
     end
   end
 

--- a/lib/bump/pull_request_creator.rb
+++ b/lib/bump/pull_request_creator.rb
@@ -44,7 +44,12 @@ module Bump
 
     def create_tree
       file_trees = files.map do |file|
-        { path: file.name, mode: "100644", type: "blob", content: file.content }
+        {
+          path: file.path.sub(%r{^/}, ""),
+          mode: "100644",
+          type: "blob",
+          content: file.content
+        }
       end
 
       github_client.create_tree(

--- a/lib/bump/pull_request_updater.rb
+++ b/lib/bump/pull_request_updater.rb
@@ -46,7 +46,12 @@ module Bump
 
     def create_tree
       file_trees = files.map do |file|
-        { path: file.name, mode: "100644", type: "blob", content: file.content }
+        {
+          path: file.path.sub(%r{^/}, ""),
+          mode: "100644",
+          type: "blob",
+          content: file.content
+        }
       end
 
       github_client.create_tree(

--- a/spec/dependency_file_fetchers/base_spec.rb
+++ b/spec/dependency_file_fetchers/base_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+require "octokit"
+require "spec_helper"
+require "bump/repo"
+require "bump/dependency_file_fetchers/ruby"
+
+RSpec.describe Bump::DependencyFileFetchers::Base do
+  let(:file_fetcher) do
+    described_class.new(repo: repo, github_client: github_client)
+  end
+  let(:repo) do
+    Bump::Repo.new(name: "gocardless/bump", language: nil, commit: nil)
+  end
+  let(:github_client) { Octokit::Client.new(access_token: "token") }
+
+  describe "#fetch_file_from_github" do
+    subject(:fetch_file_from_github) do
+      file_fetcher.send(:fetch_file_from_github, "file")
+    end
+
+    let(:url) { "https://api.github.com/repos/#{repo.name}/contents/" }
+    before do
+      stub_request(:get, url + "file").
+        to_return(status: 200,
+                  body: fixture("github", "gemfile_content.json"),
+                  headers: { "content-type" => "application/json" })
+    end
+
+    it { is_expected.to be_a(Bump::DependencyFile) }
+    its(:content) { is_expected.to include("octokit") }
+
+    context "with a directory specified" do
+      let(:file_fetcher) do
+        described_class.new(
+          repo: repo,
+          github_client: github_client,
+          directory: directory
+        )
+      end
+
+      context "that ends in a slash" do
+        let(:directory) { "app/" }
+        let(:url) { "https://api.github.com/repos/#{repo.name}/contents/app/" }
+
+        it "hits the right GitHub URL" do
+          fetch_file_from_github
+          expect(WebMock).to have_requested(:get, url + "file")
+        end
+      end
+
+      context "that begins in a slash" do
+        let(:directory) { "/app" }
+        let(:url) { "https://api.github.com/repos/#{repo.name}/contents/app/" }
+
+        it "hits the right GitHub URL" do
+          fetch_file_from_github
+          expect(WebMock).to have_requested(:get, url + "file")
+        end
+      end
+
+      context "that includes a slash" do
+        let(:directory) { "a/pp" }
+        let(:url) { "https://api.github.com/repos/#{repo.name}/contents/a/pp/" }
+
+        it "hits the right GitHub URL" do
+          fetch_file_from_github
+          expect(WebMock).to have_requested(:get, url + "file")
+        end
+      end
+    end
+
+    context "when a dependency file can't be found" do
+      before { stub_request(:get, url + "file").to_return(status: 404) }
+
+      it "raises a custom error" do
+        expect { fetch_file_from_github }.
+          to raise_error(Bump::DependencyFileNotFound) do |error|
+            expect(error.file_name).to eq("file")
+            expect(error.directory).to eq("/")
+          end
+      end
+    end
+  end
+end

--- a/spec/dependency_file_spec.rb
+++ b/spec/dependency_file_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+require "spec_helper"
+require "bump/dependency_file"
+
+RSpec.describe Bump::DependencyFile do
+  let(:file) { described_class.new(name: "Gemfile", content: "a") }
+
+  describe "#path" do
+    subject { file.path }
+
+    context "without a directory specified" do
+      it { is_expected.to eq("/Gemfile") }
+    end
+
+    context "with a directory specified" do
+      let(:file) do
+        described_class.new(name: "Gemfile", content: "a", directory: directory)
+      end
+
+      context "that starts and ends with a slash" do
+        let(:directory) { "/path/to/files/" }
+        it { is_expected.to eq("/path/to/files/Gemfile") }
+      end
+
+      context "that doesn't start or end with a slash" do
+        let(:directory) { "path/to/files" }
+        it { is_expected.to eq("/path/to/files/Gemfile") }
+      end
+    end
+  end
+
+  describe "#directory" do
+    subject { file.directory }
+
+    context "without a directory specified" do
+      it { is_expected.to eq("/") }
+    end
+
+    context "with a directory specified" do
+      let(:file) do
+        described_class.new(name: "Gemfile", content: "a", directory: directory)
+      end
+
+      context "that starts and ends with a slash" do
+        let(:directory) { "/path/to/files" }
+        it { is_expected.to eq("/path/to/files") }
+      end
+
+      context "that doesn't start or end with a slash" do
+        let(:directory) { "path/to/files" }
+        it { is_expected.to eq("/path/to/files") }
+      end
+    end
+  end
+end

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+require "spec_helper"
+require "bump/errors"
+
+RSpec.describe Bump::DependencyFileNotFound do
+  let(:error) { described_class.new(file_path) }
+  let(:file_path) { "path/to/Gemfile" }
+
+  describe "#file_name" do
+    subject { error.file_name }
+    it { is_expected.to eq("Gemfile") }
+  end
+
+  describe "#directory" do
+    subject { error.directory }
+    it { is_expected.to eq("/path/to") }
+
+    context "with the root directory" do
+      let(:file_path) { "Gemfile" }
+      it { is_expected.to eq("/") }
+    end
+
+    context "with a root level file whose path starts with a slash" do
+      let(:file_path) { "/Gemfile" }
+      it { is_expected.to eq("/") }
+    end
+
+    context "with a nested file whose path starts with a slash" do
+      let(:file_path) { "/path/to/Gemfile" }
+      it { is_expected.to eq("/path/to") }
+    end
+  end
+end

--- a/spec/pull_request_creator_spec.rb
+++ b/spec/pull_request_creator_spec.rb
@@ -28,13 +28,15 @@ RSpec.describe Bump::PullRequestCreator do
   let(:gemfile) do
     Bump::DependencyFile.new(
       name: "Gemfile",
-      content: fixture("ruby", "gemfiles", "Gemfile")
+      content: fixture("ruby", "gemfiles", "Gemfile"),
+      directory: "files/are/here"
     )
   end
   let(:gemfile_lock) do
     Bump::DependencyFile.new(
       name: "Gemfile.lock",
-      content: fixture("ruby", "lockfiles", "Gemfile.lock")
+      content: fixture("ruby", "lockfiles", "Gemfile.lock"),
+      directory: "files/are/here"
     )
   end
 
@@ -99,13 +101,13 @@ RSpec.describe Bump::PullRequestCreator do
                base_tree: "basecommitsha",
                tree: [
                  {
-                   path: "Gemfile",
+                   path: "files/are/here/Gemfile",
                    mode: "100644",
                    type: "blob",
                    content: fixture("ruby", "gemfiles", "Gemfile")
                  },
                  {
-                   path: "Gemfile.lock",
+                   path: "files/are/here/Gemfile.lock",
                    mode: "100644",
                    type: "blob",
                    content: fixture("ruby", "lockfiles", "Gemfile.lock")

--- a/spec/pull_request_updater_spec.rb
+++ b/spec/pull_request_updater_spec.rb
@@ -23,13 +23,15 @@ RSpec.describe Bump::PullRequestUpdater do
   let(:gemfile) do
     Bump::DependencyFile.new(
       name: "Gemfile",
-      content: fixture("ruby", "gemfiles", "Gemfile")
+      content: fixture("ruby", "gemfiles", "Gemfile"),
+      directory: "files/are/here"
     )
   end
   let(:gemfile_lock) do
     Bump::DependencyFile.new(
       name: "Gemfile.lock",
-      content: fixture("ruby", "lockfiles", "Gemfile.lock")
+      content: fixture("ruby", "lockfiles", "Gemfile.lock"),
+      directory: "files/are/here"
     )
   end
 
@@ -68,13 +70,13 @@ RSpec.describe Bump::PullRequestUpdater do
                base_tree: "basecommitsha",
                tree: [
                  {
-                   path: "Gemfile",
+                   path: "files/are/here/Gemfile",
                    mode: "100644",
                    type: "blob",
                    content: fixture("ruby", "gemfiles", "Gemfile")
                  },
                  {
-                   path: "Gemfile.lock",
+                   path: "files/are/here/Gemfile.lock",
                    mode: "100644",
                    type: "blob",
                    content: fixture("ruby", "lockfiles", "Gemfile.lock")


### PR DESCRIPTION
- Allow a `directory` option to be passed to DependencyFileFetcher classes
- Add accessors for a DependencyFile's `path` and `directory`
- Use the DependencyFile's path when creating or updating pull requests