### PR TITLE
Don't discard DependencyFile details when updating

### DIFF
--- a/lib/bump/dependency_file.rb
+++ b/lib/bump/dependency_file.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module Bump
   class DependencyFile
-    attr_reader :name, :content, :directory
+    attr_accessor :name, :content, :directory
 
     def initialize(name:, content:, directory: "/")
       @name = name

--- a/lib/bump/dependency_file_updaters/java_script.rb
+++ b/lib/bump/dependency_file_updaters/java_script.rb
@@ -23,17 +23,15 @@ module Bump
       end
 
       def updated_package_json_file
-        DependencyFile.new(
-          name: "package.json",
-          content: updated_package_json_content
-        )
+        new_package_json = package_json.dup
+        new_package_json.content = updated_package_json_content
+        new_package_json
       end
 
       def updated_yarn_lock
-        DependencyFile.new(
-          name: "yarn.lock",
-          content: updated_yarn_lock_content
-        )
+        new_yarn_lock = yarn_lock.dup
+        new_yarn_lock.content = updated_yarn_lock_content
+        new_yarn_lock
       end
 
       private

--- a/lib/bump/dependency_file_updaters/python.rb
+++ b/lib/bump/dependency_file_updaters/python.rb
@@ -23,10 +23,9 @@ module Bump
       end
 
       def updated_requirements_file
-        DependencyFile.new(
-          name: "requirements.txt",
-          content: updated_requirements_content
-        )
+        new_requirements = requirements.dup
+        new_requirements.content = updated_requirements_content
+        new_requirements
       end
 
       private

--- a/lib/bump/dependency_file_updaters/ruby.rb
+++ b/lib/bump/dependency_file_updaters/ruby.rb
@@ -27,17 +27,15 @@ module Bump
       end
 
       def updated_gemfile
-        DependencyFile.new(
-          name: "Gemfile",
-          content: updated_gemfile_content
-        )
+        new_gemfile = gemfile.dup
+        new_gemfile.content = updated_gemfile_content
+        new_gemfile
       end
 
       def updated_gemfile_lock
-        DependencyFile.new(
-          name: "Gemfile.lock",
-          content: updated_gemfile_lock_content
-        )
+        new_lockfile = gemfile_lock.dup
+        new_lockfile.content = updated_gemfile_lock_content
+        new_lockfile
       end
 
       private


### PR DESCRIPTION
We should only be updating the file contents, not any of the metadata passed around about it.