### PR TITLE
Refactor file updaters

### DIFF
--- a/lib/bump/dependency_file_updaters/base.rb
+++ b/lib/bump/dependency_file_updaters/base.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+module Bump
+  module DependencyFileUpdaters
+    class Base
+      attr_reader :dependency, :dependency_files, :github_access_token
+
+      def initialize(dependency:, dependency_files:, github_access_token:)
+        @dependency = dependency
+        @dependency_files = dependency_files
+        @github_access_token = github_access_token
+      end
+
+      def updated_dependency_files
+        raise NotImplementedError
+      end
+
+      private
+
+      def get_original_file(filename)
+        file = dependency_files.find { |f| f.name == filename }
+
+        raise "No #{filename}!" unless file
+        file
+      end
+
+      def updated_file(file:, content:)
+        updated_file = file.dup
+        updated_file.content = content
+        updated_file
+      end
+    end
+  end
+end

--- a/lib/bump/dependency_file_updaters/base.rb
+++ b/lib/bump/dependency_file_updaters/base.rb
@@ -8,19 +8,24 @@ module Bump
         @dependency = dependency
         @dependency_files = dependency_files
         @github_access_token = github_access_token
+
+        required_files.each do |filename|
+          raise "No #{filename}!" unless get_original_file(filename)
+        end
       end
 
       def updated_dependency_files
         raise NotImplementedError
       end
 
+      def required_files
+        raise NotImplementedError
+      end
+
       private
 
       def get_original_file(filename)
-        file = dependency_files.find { |f| f.name == filename }
-
-        raise "No #{filename}!" unless file
-        file
+        dependency_files.find { |f| f.name == filename }
       end
 
       def updated_file(file:, content:)

--- a/lib/bump/dependency_file_updaters/java_script.rb
+++ b/lib/bump/dependency_file_updaters/java_script.rb
@@ -5,20 +5,18 @@ require "bump/shared_helpers"
 module Bump
   module DependencyFileUpdaters
     class JavaScript < Base
-      def updated_dependency_files
-        [updated_package_json_file, updated_yarn_lock]
-      end
-
-      def updated_package_json_file
-        updated_file(file: package_json, content: updated_package_json_content)
-      end
-
-      def updated_yarn_lock
-        updated_file(file: yarn_lock, content: updated_yarn_lock_content)
-      end
-
       def required_files
         %w(package.json yarn.lock)
+      end
+
+      def updated_dependency_files
+        [
+          updated_file(
+            file: package_json,
+            content: updated_package_json_content
+          ),
+          updated_file(file: yarn_lock, content: updated_yarn_lock_content)
+        ]
       end
 
       private

--- a/lib/bump/dependency_file_updaters/java_script.rb
+++ b/lib/bump/dependency_file_updaters/java_script.rb
@@ -48,6 +48,7 @@ module Bump
 
       def updated_yarn_lock_content
         return @updated_yarn_lock_content if @updated_yarn_lock_content
+
         SharedHelpers.in_a_temporary_directory do |dir|
           File.write(File.join(dir, "yarn.lock"), yarn_lock.content)
           File.write(File.join(dir, "package.json"),

--- a/lib/bump/dependency_file_updaters/java_script.rb
+++ b/lib/bump/dependency_file_updaters/java_script.rb
@@ -1,21 +1,17 @@
 # frozen_string_literal: true
-require "gemnasium/parser"
-require "bundler"
-require "bump/dependency_file"
+require "bump/dependency_file_updaters/base"
 require "bump/shared_helpers"
 
 module Bump
   module DependencyFileUpdaters
-    class JavaScript
-      attr_reader :package_json, :yarn_lock, :dependency
+    class JavaScript < Base
+      attr_reader :package_json, :yarn_lock
 
-      def initialize(dependency_files:, dependency:, github_access_token:)
-        @package_json = dependency_files.find { |f| f.name == "package.json" }
-        @yarn_lock = dependency_files.find { |file| file.name == "yarn.lock" }
-        validate_files_are_present!
+      def initialize(**args)
+        super(args)
 
-        @github_access_token = github_access_token
-        @dependency = dependency
+        @package_json = get_original_file("package.json")
+        @yarn_lock = get_original_file("yarn.lock")
       end
 
       def updated_dependency_files
@@ -23,23 +19,14 @@ module Bump
       end
 
       def updated_package_json_file
-        new_package_json = package_json.dup
-        new_package_json.content = updated_package_json_content
-        new_package_json
+        updated_file(file: package_json, content: updated_package_json_content)
       end
 
       def updated_yarn_lock
-        new_yarn_lock = yarn_lock.dup
-        new_yarn_lock.content = updated_yarn_lock_content
-        new_yarn_lock
+        updated_file(file: yarn_lock, content: updated_yarn_lock_content)
       end
 
       private
-
-      def validate_files_are_present!
-        raise "No package.json!" unless package_json
-        raise "No yarn.lock!" unless yarn_lock
-      end
 
       def updated_package_json_content
         return @updated_package_json_content if @updated_package_json_content

--- a/lib/bump/dependency_file_updaters/python.rb
+++ b/lib/bump/dependency_file_updaters/python.rb
@@ -1,21 +1,16 @@
 # frozen_string_literal: true
-require "bump/dependency_file"
-require "bump/dependency"
+require "bump/dependency_file_updaters/base"
 require "bump/dependency_file_parsers/python"
 
 module Bump
   module DependencyFileUpdaters
-    class Python
-      attr_reader :requirements, :dependency
+    class Python < Base
+      attr_reader :requirements
 
-      def initialize(dependency_files:, dependency:, github_access_token:)
-        @requirements =
-          dependency_files.find { |f| f.name == "requirements.txt" }
+      def initialize(**args)
+        super(args)
 
-        raise "No requirements.txt!" unless requirements
-
-        @github_access_token = github_access_token
-        @dependency = dependency
+        @requirements = get_original_file("requirements.txt")
       end
 
       def updated_dependency_files
@@ -23,9 +18,7 @@ module Bump
       end
 
       def updated_requirements_file
-        new_requirements = requirements.dup
-        new_requirements.content = updated_requirements_content
-        new_requirements
+        updated_file(file: requirements, content: updated_requirements_content)
       end
 
       private

--- a/lib/bump/dependency_file_updaters/python.rb
+++ b/lib/bump/dependency_file_updaters/python.rb
@@ -5,16 +5,17 @@ require "bump/dependency_file_parsers/python"
 module Bump
   module DependencyFileUpdaters
     class Python < Base
-      def updated_dependency_files
-        [updated_requirements_file]
-      end
-
-      def updated_requirements_file
-        updated_file(file: requirements, content: updated_requirements_content)
-      end
-
       def required_files
         %w(requirements.txt)
+      end
+
+      def updated_dependency_files
+        [
+          updated_file(
+            file: requirements,
+            content: updated_requirements_content
+          )
+        ]
       end
 
       private

--- a/lib/bump/dependency_file_updaters/python.rb
+++ b/lib/bump/dependency_file_updaters/python.rb
@@ -5,14 +5,6 @@ require "bump/dependency_file_parsers/python"
 module Bump
   module DependencyFileUpdaters
     class Python < Base
-      attr_reader :requirements
-
-      def initialize(**args)
-        super(args)
-
-        @requirements = get_original_file("requirements.txt")
-      end
-
       def updated_dependency_files
         [updated_requirements_file]
       end
@@ -21,7 +13,15 @@ module Bump
         updated_file(file: requirements, content: updated_requirements_content)
       end
 
+      def required_files
+        %w(requirements.txt)
+      end
+
       private
+
+      def requirements
+        @requirements ||= get_original_file("requirements.txt")
+      end
 
       def updated_requirements_content
         return @updated_requirements_content if @updated_requirements_content

--- a/lib/bump/dependency_file_updaters/ruby.rb
+++ b/lib/bump/dependency_file_updaters/ruby.rb
@@ -8,7 +8,7 @@ require "bump/dependency_file_updaters/base"
 module Bump
   module DependencyFileUpdaters
     class Ruby < Base
-      attr_reader :gemfile, :gemfile_lock
+      attr_reader :gemfile, :lockfile
 
       LOCKFILE_ENDING = /(?<ending>\s*(?:RUBY VERSION|BUNDLED WITH).*)/m
       GIT_COMMAND_ERROR_REGEX = /`(?<command>.*)`/
@@ -17,19 +17,19 @@ module Bump
         super(args)
 
         @gemfile = get_original_file("Gemfile")
-        @gemfile_lock = get_original_file("Gemfile.lock")
+        @lockfile = get_original_file("Gemfile.lock")
       end
 
       def updated_dependency_files
-        [updated_gemfile, updated_gemfile_lock]
+        [updated_gemfile, updated_lockfile]
       end
 
       def updated_gemfile
         updated_file(file: gemfile, content: updated_gemfile_content)
       end
 
-      def updated_gemfile_lock
-        updated_file(file: gemfile_lock, content: updated_gemfile_lock_content)
+      def updated_lockfile
+        updated_file(file: lockfile, content: updated_lockfile_content)
       end
 
       private
@@ -61,11 +61,11 @@ module Bump
         )
       end
 
-      def updated_gemfile_lock_content
-        @updated_gemfile_lock_content ||= build_updated_gemfile_lock
+      def updated_lockfile_content
+        @updated_lockfile_content ||= build_updated_lockfile
       end
 
-      def build_updated_gemfile_lock
+      def build_updated_lockfile
         lockfile_body =
           SharedHelpers.in_a_temporary_directory do |dir|
             write_temporary_dependency_files_to(dir)
@@ -104,7 +104,7 @@ module Bump
         )
         File.write(
           File.join(dir, "Gemfile.lock"),
-          gemfile_lock.content.gsub(
+          lockfile.content.gsub(
             "git@github.com:",
             "https://#{github_access_token}:x-oauth-basic@github.com/"
           )
@@ -140,7 +140,7 @@ module Bump
         # Re-add any explicit Ruby version, and the old `BUNDLED WITH` version
         lockfile_body.gsub(
           LOCKFILE_ENDING,
-          gemfile_lock.content.match(LOCKFILE_ENDING)&.[](:ending) || "\n"
+          lockfile.content.match(LOCKFILE_ENDING)&.[](:ending) || "\n"
         )
       end
     end

--- a/lib/bump/dependency_file_updaters/ruby.rb
+++ b/lib/bump/dependency_file_updaters/ruby.rb
@@ -11,20 +11,15 @@ module Bump
       LOCKFILE_ENDING = /(?<ending>\s*(?:RUBY VERSION|BUNDLED WITH).*)/m
       GIT_COMMAND_ERROR_REGEX = /`(?<command>.*)`/
 
-      def updated_dependency_files
-        [updated_gemfile, updated_lockfile]
-      end
-
       def required_files
         %w(Gemfile Gemfile.lock)
       end
 
-      def updated_gemfile
-        updated_file(file: gemfile, content: updated_gemfile_content)
-      end
-
-      def updated_lockfile
-        updated_file(file: lockfile, content: updated_lockfile_content)
+      def updated_dependency_files
+        [
+          updated_file(file: gemfile, content: updated_gemfile_content),
+          updated_file(file: lockfile, content: updated_lockfile_content)
+        ]
       end
 
       private

--- a/lib/bump/dependency_file_updaters/ruby.rb
+++ b/lib/bump/dependency_file_updaters/ruby.rb
@@ -8,20 +8,15 @@ require "bump/dependency_file_updaters/base"
 module Bump
   module DependencyFileUpdaters
     class Ruby < Base
-      attr_reader :gemfile, :lockfile
-
       LOCKFILE_ENDING = /(?<ending>\s*(?:RUBY VERSION|BUNDLED WITH).*)/m
       GIT_COMMAND_ERROR_REGEX = /`(?<command>.*)`/
 
-      def initialize(**args)
-        super(args)
-
-        @gemfile = get_original_file("Gemfile")
-        @lockfile = get_original_file("Gemfile.lock")
-      end
-
       def updated_dependency_files
         [updated_gemfile, updated_lockfile]
+      end
+
+      def required_files
+        %w(Gemfile Gemfile.lock)
       end
 
       def updated_gemfile
@@ -33,6 +28,14 @@ module Bump
       end
 
       private
+
+      def gemfile
+        @gemfile ||= get_original_file("Gemfile")
+      end
+
+      def lockfile
+        @lockfile ||= get_original_file("Gemfile.lock")
+      end
 
       def updated_gemfile_content
         return @updated_gemfile_content if @updated_gemfile_content

--- a/spec/dependency_file_updaters/base_spec.rb
+++ b/spec/dependency_file_updaters/base_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+require "spec_helper"
+require "bump/dependency"
+require "bump/dependency_file"
+require "bump/dependency_file_updaters/base"
+
+RSpec.describe Bump::DependencyFileUpdaters::Base do
+  let(:child_class) do
+    Class.new(described_class) do
+      def required_files
+        ["Gemfile"]
+      end
+    end
+  end
+  let(:updater_instance) do
+    child_class.new(
+      dependency_files: files,
+      dependency: dependency,
+      github_access_token: github_access_token
+    )
+  end
+
+  let(:gemfile) do
+    Bump::DependencyFile.new(
+      content: "a",
+      name: "Gemfile",
+      directory: "/path/to"
+    )
+  end
+  let(:dependency) { Bump::Dependency.new(name: "business", version: "1.5.0") }
+  let(:github_access_token) { "token" }
+  let(:files) { [gemfile] }
+
+  describe ".new" do
+    subject { -> { updater_instance } }
+
+    context "when the required file is present" do
+      let(:files) { [gemfile] }
+      it { is_expected.to_not raise_error }
+    end
+
+    context "when the required file is missing" do
+      let(:files) { [] }
+      it { is_expected.to raise_error(/No Gemfile/) }
+    end
+  end
+
+  describe "#get_original_file" do
+    subject { updater_instance.send(:get_original_file, filename) }
+
+    context "when the requested file is present" do
+      let(:filename) { "Gemfile" }
+      it { is_expected.to eq(gemfile) }
+    end
+
+    context "when the requested file is not present" do
+      let(:filename) { "Unknown.file" }
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe "#updated_file" do
+    subject(:updated_file) do
+      updater_instance.send(:updated_file, file: file, content: content)
+    end
+    let(:file) { gemfile }
+    let(:content) { "codes" }
+
+    it { is_expected.to be_a(Bump::DependencyFile) }
+    its(:content) { is_expected.to eq("codes") }
+    its(:directory) { is_expected.to eq(file.directory) }
+
+    specify { expect { updated_file }.to_not(change { file.content }) }
+  end
+end

--- a/spec/dependency_file_updaters/java_script_spec.rb
+++ b/spec/dependency_file_updaters/java_script_spec.rb
@@ -33,21 +33,6 @@ RSpec.describe Bump::DependencyFileUpdaters::JavaScript do
 
   before { Dir.mkdir(tmp_path) unless Dir.exist?(tmp_path) }
 
-  describe "new" do
-    context "when the package.json is missing" do
-      subject { -> { updater } }
-      let(:updater) do
-        described_class.new(
-          dependency_files: [],
-          dependency: dependency,
-          github_access_token: "token"
-        )
-      end
-
-      it { is_expected.to raise_error(/No package.json!/) }
-    end
-  end
-
   describe "#updated_dependency_files" do
     subject(:updated_files) { updater.updated_dependency_files }
 

--- a/spec/dependency_file_updaters/java_script_spec.rb
+++ b/spec/dependency_file_updaters/java_script_spec.rb
@@ -61,31 +61,36 @@ RSpec.describe Bump::DependencyFileUpdaters::JavaScript do
 
     specify { expect { updated_files }.to_not output.to_stdout }
     its(:length) { is_expected.to eq(2) }
-  end
 
-  describe "#updated_package_json_file" do
-    subject(:updated_package_json_file) { updater.updated_package_json_file }
-
-    its(:content) { is_expected.to include "\"fetch-factory\": \"^0.0.2\"" }
-    its(:content) { is_expected.to include "\"etag\": \"^1.0.0\"" }
-
-    context "when the minor version is specified" do
-      let(:dependency) do
-        Bump::Dependency.new(name: "fetch-factory", version: "0.2.1")
-      end
-      let(:package_json_body) do
-        fixture("javascript", "package_files", "minor_version_specified.json")
+    describe "the updated package_json_file" do
+      subject(:updated_package_json_file) do
+        updated_files.find { |f| f.name == "package.json" }
       end
 
-      its(:content) { is_expected.to include "\"fetch-factory\": \"0.2.x\"" }
+      its(:content) { is_expected.to include "\"fetch-factory\": \"^0.0.2\"" }
+      its(:content) { is_expected.to include "\"etag\": \"^1.0.0\"" }
+
+      context "when the minor version is specified" do
+        let(:dependency) do
+          Bump::Dependency.new(name: "fetch-factory", version: "0.2.1")
+        end
+        let(:package_json_body) do
+          fixture("javascript", "package_files", "minor_version_specified.json")
+        end
+
+        its(:content) { is_expected.to include "\"fetch-factory\": \"0.2.x\"" }
+      end
     end
-  end
 
-  describe "#updated_yarn_lock" do
-    subject(:file) { updater.updated_yarn_lock }
-    it "has details of the updated item" do
-      expect(file.content).
-        to include("fetch-factory@^0.0.2")
+    describe "the updated yarn_lock" do
+      subject(:updated_yarn_lock_file) do
+        updated_files.find { |f| f.name == "yarn.lock" }
+      end
+
+      it "has details of the updated item" do
+        expect(updated_yarn_lock_file.content).
+          to include("fetch-factory@^0.0.2")
+      end
     end
   end
 end

--- a/spec/dependency_file_updaters/python_spec.rb
+++ b/spec/dependency_file_updaters/python_spec.rb
@@ -27,21 +27,6 @@ RSpec.describe Bump::DependencyFileUpdaters::Python do
 
   before { Dir.mkdir(tmp_path) unless Dir.exist?(tmp_path) }
 
-  describe "new" do
-    context "when the requirements.txt is missing" do
-      subject { -> { updater } }
-      let(:updater) do
-        described_class.new(
-          dependency_files: [],
-          dependency: dependency,
-          github_access_token: "token"
-        )
-      end
-
-      it { is_expected.to raise_error(/No requirements.txt!/) }
-    end
-  end
-
   describe "#updated_dependency_files" do
     subject(:updated_files) { updater.updated_dependency_files }
 

--- a/spec/dependency_file_updaters/python_spec.rb
+++ b/spec/dependency_file_updaters/python_spec.rb
@@ -54,35 +54,37 @@ RSpec.describe Bump::DependencyFileUpdaters::Python do
     end
 
     its(:length) { is_expected.to eq(1) }
-  end
 
-  describe "#updated_requirements_file" do
-    subject(:updated_requirements_file) { updater.updated_requirements_file }
-
-    its(:content) { is_expected.to include "psycopg2==2.8.1\n" }
-    its(:content) { is_expected.to include "luigi==2.2.0\n" }
-
-    context "when only the minor version is specified" do
-      let(:requirements_body) do
-        fixture("python", "requirements", "minor_version_specified.txt")
+    describe "the updated requirements_file" do
+      subject(:updated_requirements_file) do
+        updated_files.find { |f| f.name == "requirements.txt" }
       end
 
-      its(:content) { is_expected.to include "psycopg2==2.8\n" }
-    end
-
-    context "when there is a comment" do
-      let(:requirements_body) do
-        fixture("python", "requirements", "comments.txt")
-      end
-      its(:content) { is_expected.to include "psycopg2==2.8.1  # Comment!\n" }
-    end
-
-    context "when there are unused lines" do
-      let(:requirements_body) do
-        fixture("python", "requirements", "invalid_lines.txt")
-      end
       its(:content) { is_expected.to include "psycopg2==2.8.1\n" }
-      its(:content) { is_expected.to include "# This is just a comment" }
+      its(:content) { is_expected.to include "luigi==2.2.0\n" }
+
+      context "when only the minor version is specified" do
+        let(:requirements_body) do
+          fixture("python", "requirements", "minor_version_specified.txt")
+        end
+
+        its(:content) { is_expected.to include "psycopg2==2.8\n" }
+      end
+
+      context "when there is a comment" do
+        let(:requirements_body) do
+          fixture("python", "requirements", "comments.txt")
+        end
+        its(:content) { is_expected.to include "psycopg2==2.8.1  # Comment!\n" }
+      end
+
+      context "when there are unused lines" do
+        let(:requirements_body) do
+          fixture("python", "requirements", "invalid_lines.txt")
+        end
+        its(:content) { is_expected.to include "psycopg2==2.8.1\n" }
+        its(:content) { is_expected.to include "# This is just a comment" }
+      end
     end
   end
 end

--- a/spec/dependency_file_updaters/ruby_spec.rb
+++ b/spec/dependency_file_updaters/ruby_spec.rb
@@ -68,151 +68,165 @@ RSpec.describe Bump::DependencyFileUpdaters::Ruby do
     end
 
     its(:length) { is_expected.to eq(2) }
-  end
 
-  describe "#updated_gemfile" do
-    subject(:updated_gemfile) { updater.updated_gemfile }
-
-    context "when the full version is specified" do
-      let(:gemfile_body) { fixture("ruby", "gemfiles", "version_specified") }
-      its(:content) { is_expected.to include "\"business\", \"~> 1.5.0\"" }
-      its(:content) { is_expected.to include "\"statesman\", \"~> 1.2.0\"" }
-    end
-
-    context "when the minor version is specified" do
-      let(:gemfile_body) do
-        fixture("ruby", "gemfiles", "minor_version_specified")
-      end
-      its(:content) { is_expected.to include "\"business\", \"~> 1.5\"" }
-      its(:content) { is_expected.to include "\"statesman\", \"~> 1.2\"" }
-    end
-
-    context "with a gem whose name includes a number" do
-      let(:gemfile_body) { fixture("ruby", "gemfiles", "gem_with_number") }
-      let(:dependency) { Bump::Dependency.new(name: "i18n", version: "1.5.0") }
-      its(:content) { is_expected.to include "\"i18n\", \"~> 1.5.0\"" }
-    end
-
-    context "when there is a comment" do
-      let(:gemfile_body) { fixture("ruby", "gemfiles", "comments") }
-      its(:content) do
-        is_expected.to include "\"business\", \"~> 1.5.0\"   # Business time"
-      end
-    end
-  end
-
-  describe "#updated_lockfile" do
-    subject(:file) { updater.updated_lockfile }
-
-    context "when the old Gemfile specified the version" do
-      let(:gemfile_body) { fixture("ruby", "gemfiles", "version_specified") }
-
-      it "locks the updated gem to the latest version" do
-        expect(file.content).to include "business (1.5.0)"
+    describe "the updated gemfile" do
+      subject(:updated_gemfile) do
+        updated_files.find { |f| f.name == "Gemfile" }
       end
 
-      it "doesn't change the version of the other (also outdated) gem" do
-        expect(file.content).to include "statesman (1.2.1)"
+      context "when the full version is specified" do
+        let(:gemfile_body) { fixture("ruby", "gemfiles", "version_specified") }
+        its(:content) { is_expected.to include "\"business\", \"~> 1.5.0\"" }
+        its(:content) { is_expected.to include "\"statesman\", \"~> 1.2.0\"" }
       end
 
-      it "preserves the BUNDLED WITH line in the lockfile" do
-        expect(file.content).to include "BUNDLED WITH\n   1.10.6"
+      context "when the minor version is specified" do
+        let(:gemfile_body) do
+          fixture("ruby", "gemfiles", "minor_version_specified")
+        end
+        its(:content) { is_expected.to include "\"business\", \"~> 1.5\"" }
+        its(:content) { is_expected.to include "\"statesman\", \"~> 1.2\"" }
       end
 
-      it "doesn't add in a RUBY VERSION" do
-        expect(file.content).to_not include "RUBY VERSION"
-      end
-    end
-
-    context "when the Gemfile specifies a Ruby version" do
-      let(:gemfile_body) { fixture("ruby", "gemfiles", "explicit_ruby") }
-      let(:lockfile_body) { fixture("ruby", "lockfiles", "explicit_ruby.lock") }
-
-      it "locks the updated gem to the latest version" do
-        expect(file.content).to include "business (1.5.0)"
-      end
-
-      it "preserves the Ruby version in the lockfile" do
-        expect(file.content).to include "RUBY VERSION\n   ruby 2.2.0p0"
-      end
-    end
-
-    context "when the Gemfile.lock didn't have a BUNDLED WITH line" do
-      let(:lockfile_body) do
-        fixture("ruby", "lockfiles", "no_bundled_with.lock")
+      context "with a gem whose name includes a number" do
+        let(:gemfile_body) { fixture("ruby", "gemfiles", "gem_with_number") }
+        let(:dependency) do
+          Bump::Dependency.new(name: "i18n", version: "0.5.0")
+        end
+        before do
+          url = "https://index.rubygems.org/api/v1/dependencies?gems=i18n"
+          stub_request(:get, url).
+            to_return(status: 200, body: fixture("rubygems-dependencies-i18n"))
+        end
+        its(:content) { is_expected.to include "\"i18n\", \"~> 0.5.0\"" }
       end
 
-      it "doesn't add in a BUNDLED WITH" do
-        expect(file.content).to_not include "BUNDLED WITH"
-      end
-    end
-
-    context "when the old Gemfile didn't specify the version" do
-      let(:gemfile_body) do
-        fixture("ruby", "gemfiles", "version_not_specified")
-      end
-
-      it "locks the updated gem to the latest version" do
-        expect(file.content).to include "business (1.8.0)"
-      end
-
-      it "doesn't change the version of the other (also outdated) gem" do
-        expect(file.content).to include "statesman (1.2.1)"
-      end
-    end
-
-    context "when the Gem can't be found" do
-      let(:gemfile_body) { fixture("ruby", "gemfiles", "unavailable_gem") }
-
-      it "raises a Bump::SharedHelpers::ChildProcessFailed error" do
-        expect { updater.updated_lockfile }.
-          to raise_error(Bump::SharedHelpers::ChildProcessFailed)
-      end
-    end
-
-    context "when another gem in the Gemfile has a git source" do
-      let(:gemfile_body) { fixture("ruby", "gemfiles", "git_source") }
-
-      it "updates the gem just fine" do
-        expect(file.content).to include "business (1.5.0)"
-      end
-
-      context "that is private" do
-        let(:gemfile_body) { fixture("ruby", "gemfiles", "private_git_source") }
-        around { |example| capture_stderr { example.run } }
-
-        it "raises a helpful error" do
-          expect { updater.updated_lockfile }.
-            to raise_error do |error|
-              expect(error).to be_a(Bump::GitCommandError)
-              expect(error.command).to start_with("git clone 'https://github")
-            end
+      context "when there is a comment" do
+        let(:gemfile_body) { fixture("ruby", "gemfiles", "comments") }
+        its(:content) do
+          is_expected.to include "\"business\", \"~> 1.5.0\"   # Business time"
         end
       end
     end
 
-    context "when there is a version conflict" do
-      let(:gemfile_body) { fixture("ruby", "gemfiles", "version_conflict") }
-      let(:dependency) do
-        Bump::Dependency.new(name: "ibandit", version: "0.8.5")
+    describe "the updated lockfile" do
+      subject(:file) { updated_files.find { |f| f.name == "Gemfile.lock" } }
+
+      context "when the old Gemfile specified the version" do
+        let(:gemfile_body) { fixture("ruby", "gemfiles", "version_specified") }
+
+        it "locks the updated gem to the latest version" do
+          expect(file.content).to include "business (1.5.0)"
+        end
+
+        it "doesn't change the version of the other (also outdated) gem" do
+          expect(file.content).to include "statesman (1.2.1)"
+        end
+
+        it "preserves the BUNDLED WITH line in the lockfile" do
+          expect(file.content).to include "BUNDLED WITH\n   1.10.6"
+        end
+
+        it "doesn't add in a RUBY VERSION" do
+          expect(file.content).to_not include "RUBY VERSION"
+        end
       end
 
-      before do
-        url = "https://index.rubygems.org/api/v1/dependencies?gems=i18n,ibandit"
-        stub_request(:get, url).
-          to_return(
-            status: 200,
-            body: fixture("rubygems-dependencies-i18n-ibandit")
-          )
+      context "when the Gemfile specifies a Ruby version" do
+        let(:gemfile_body) { fixture("ruby", "gemfiles", "explicit_ruby") }
+        let(:lockfile_body) do
+          fixture("ruby", "lockfiles", "explicit_ruby.lock")
+        end
 
-        url = "https://index.rubygems.org/api/v1/dependencies?gems=i18n"
-        stub_request(:get, url).
-          to_return(status: 200, body: fixture("rubygems-dependencies-i18n"))
+        it "locks the updated gem to the latest version" do
+          expect(file.content).to include "business (1.5.0)"
+        end
+
+        it "preserves the Ruby version in the lockfile" do
+          expect(file.content).to include "RUBY VERSION\n   ruby 2.2.0p0"
+        end
       end
 
-      it "raises a Bump::VersionConflict error" do
-        expect { updater.updated_lockfile }.
-          to raise_error(Bump::VersionConflict)
+      context "when the Gemfile.lock didn't have a BUNDLED WITH line" do
+        let(:lockfile_body) do
+          fixture("ruby", "lockfiles", "no_bundled_with.lock")
+        end
+
+        it "doesn't add in a BUNDLED WITH" do
+          expect(file.content).to_not include "BUNDLED WITH"
+        end
+      end
+
+      context "when the old Gemfile didn't specify the version" do
+        let(:gemfile_body) do
+          fixture("ruby", "gemfiles", "version_not_specified")
+        end
+
+        it "locks the updated gem to the latest version" do
+          expect(file.content).to include "business (1.8.0)"
+        end
+
+        it "doesn't change the version of the other (also outdated) gem" do
+          expect(file.content).to include "statesman (1.2.1)"
+        end
+      end
+
+      context "when the Gem can't be found" do
+        let(:gemfile_body) { fixture("ruby", "gemfiles", "unavailable_gem") }
+
+        it "raises a Bump::SharedHelpers::ChildProcessFailed error" do
+          expect { updater.updated_dependency_files }.
+            to raise_error(Bump::SharedHelpers::ChildProcessFailed)
+        end
+      end
+
+      context "when another gem in the Gemfile has a git source" do
+        let(:gemfile_body) { fixture("ruby", "gemfiles", "git_source") }
+
+        it "updates the gem just fine" do
+          expect(file.content).to include "business (1.5.0)"
+        end
+
+        context "that is private" do
+          let(:gemfile_body) do
+            fixture("ruby", "gemfiles", "private_git_source")
+          end
+          around { |example| capture_stderr { example.run } }
+
+          it "raises a helpful error" do
+            expect { updater.updated_dependency_files }.
+              to raise_error do |error|
+                expect(error).to be_a(Bump::GitCommandError)
+                expect(error.command).to start_with("git clone 'https://github")
+              end
+          end
+        end
+      end
+
+      context "when there is a version conflict" do
+        let(:gemfile_body) { fixture("ruby", "gemfiles", "version_conflict") }
+        let(:dependency) do
+          Bump::Dependency.new(name: "ibandit", version: "0.8.5")
+        end
+
+        before do
+          url = "https://index.rubygems.org/api/v1/dependencies?"\
+                "gems=i18n,ibandit"
+          stub_request(:get, url).
+            to_return(
+              status: 200,
+              body: fixture("rubygems-dependencies-i18n-ibandit")
+            )
+
+          url = "https://index.rubygems.org/api/v1/dependencies?gems=i18n"
+          stub_request(:get, url).
+            to_return(status: 200, body: fixture("rubygems-dependencies-i18n"))
+        end
+
+        it "raises a Bump::VersionConflict error" do
+          expect { updater.updated_dependency_files }.
+            to raise_error(Bump::VersionConflict)
+        end
       end
     end
   end

--- a/spec/dependency_file_updaters/ruby_spec.rb
+++ b/spec/dependency_file_updaters/ruby_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Bump::DependencyFileUpdaters::Ruby do
 
   let(:updater) do
     described_class.new(
-      dependency_files: [gemfile, gemfile_lock],
+      dependency_files: [gemfile, lockfile],
       dependency: dependency,
       github_access_token: "token"
     )
@@ -32,7 +32,7 @@ RSpec.describe Bump::DependencyFileUpdaters::Ruby do
     Bump::DependencyFile.new(content: gemfile_body, name: "Gemfile")
   end
   let(:gemfile_body) { fixture("ruby", "gemfiles", "Gemfile") }
-  let(:gemfile_lock) do
+  let(:lockfile) do
     Bump::DependencyFile.new(content: lockfile_body, name: "Gemfile.lock")
   end
   let(:lockfile_body) { fixture("ruby", "lockfiles", "Gemfile.lock") }
@@ -101,8 +101,8 @@ RSpec.describe Bump::DependencyFileUpdaters::Ruby do
     end
   end
 
-  describe "#updated_gemfile_lock" do
-    subject(:file) { updater.updated_gemfile_lock }
+  describe "#updated_lockfile" do
+    subject(:file) { updater.updated_lockfile }
 
     context "when the old Gemfile specified the version" do
       let(:gemfile_body) { fixture("ruby", "gemfiles", "version_specified") }
@@ -165,7 +165,7 @@ RSpec.describe Bump::DependencyFileUpdaters::Ruby do
       let(:gemfile_body) { fixture("ruby", "gemfiles", "unavailable_gem") }
 
       it "raises a Bump::SharedHelpers::ChildProcessFailed error" do
-        expect { updater.updated_gemfile_lock }.
+        expect { updater.updated_lockfile }.
           to raise_error(Bump::SharedHelpers::ChildProcessFailed)
       end
     end
@@ -182,7 +182,7 @@ RSpec.describe Bump::DependencyFileUpdaters::Ruby do
         around { |example| capture_stderr { example.run } }
 
         it "raises a helpful error" do
-          expect { updater.updated_gemfile_lock }.
+          expect { updater.updated_lockfile }.
             to raise_error do |error|
               expect(error).to be_a(Bump::GitCommandError)
               expect(error.command).to start_with("git clone 'https://github")
@@ -211,7 +211,7 @@ RSpec.describe Bump::DependencyFileUpdaters::Ruby do
       end
 
       it "raises a Bump::VersionConflict error" do
-        expect { updater.updated_gemfile_lock }.
+        expect { updater.updated_lockfile }.
           to raise_error(Bump::VersionConflict)
       end
     end

--- a/spec/dependency_file_updaters/ruby_spec.rb
+++ b/spec/dependency_file_updaters/ruby_spec.rb
@@ -41,21 +41,6 @@ RSpec.describe Bump::DependencyFileUpdaters::Ruby do
 
   before { Dir.mkdir(tmp_path) unless Dir.exist?(tmp_path) }
 
-  describe "new" do
-    context "when the gemfile.lock is missing" do
-      subject { -> { updater } }
-      let(:updater) do
-        described_class.new(
-          dependency_files: [gemfile],
-          dependency: dependency,
-          github_access_token: "token"
-        )
-      end
-
-      it { is_expected.to raise_error(/No Gemfile.lock/) }
-    end
-  end
-
   describe "#updated_dependency_files" do
     subject(:updated_files) { updater.updated_dependency_files }
 

--- a/spec/fixtures/ruby/gemfiles/gem_with_number
+++ b/spec/fixtures/ruby/gemfiles/gem_with_number
@@ -1,4 +1,3 @@
 source "https://rubygems.org"
 
-gem "business", "~> 1.4"
-gem "i18n", "~> 1.2.0"
+gem "i18n", "~> 0.4.0"


### PR DESCRIPTION
Previously, there was quite a bit of duplication in the `DependencyFileUpdaters` classes. In particular:
- Each class implemented its own logic for checking that its required files were present
- Each class implemented its own logic for updating the content of a dependency file (as distinct from generating the updated content)

This PR moves those two concerns out onto a properly specced base class. The contract for writing a new `DependencyFileUpdaters` class is therefore much simpler - the class just has to implement the `required_files` and `updated_dependency_files` methods.