### PR TITLE
Escape scoped package names in Bump::DependencyMetadataFinders::JavaScript

### DIFF
--- a/lib/bump/dependency_metadata_finders/java_script.rb
+++ b/lib/bump/dependency_metadata_finders/java_script.rb
@@ -12,7 +12,6 @@ module Bump
         return @github_repo if @github_repo_lookup_attempted
         @github_repo_lookup_attempted = true
 
-        npm_url = "http://registry.npmjs.org/#{dependency.name}"
         npm_response =
           Excon.get(npm_url, middlewares: SharedHelpers.excon_middleware)
         all_versions = JSON.parse(npm_response.body)["versions"]&.values
@@ -34,6 +33,12 @@ module Bump
         when String then details
         when Hash then details.fetch("url", nil)
         end
+      end
+
+      def npm_url
+        # NPM registry expects slashes to be escaped
+        path = dependency.name.gsub("/", "%2f")
+        "http://registry.npmjs.org/#{path}"
       end
     end
   end

--- a/lib/bump/update_checkers/java_script.rb
+++ b/lib/bump/update_checkers/java_script.rb
@@ -26,6 +26,7 @@ module Bump
       private
 
       def dependency_url
+        # NPM registry expects slashes to be escaped
         path = dependency.name.gsub("/", "%2F")
         "http://registry.npmjs.org/#{path}"
       end

--- a/spec/dependency_metadata_finders/java_script_spec.rb
+++ b/spec/dependency_metadata_finders/java_script_spec.rb
@@ -72,5 +72,21 @@ RSpec.describe Bump::DependencyMetadataFinders::JavaScript do
 
       it { is_expected.to eq("kesla/etag") }
     end
+
+    context "for a scoped package name" do
+      before do
+        stub_request(:get, "http://registry.npmjs.org/@etag%2Fsomething").
+          to_return(status: 200, body: npm_response)
+      end
+      let(:dependency_name) { "@etag/something" }
+      let(:npm_response) { fixture("npm_response.json") }
+
+      it "requests the escaped name" do
+        finder.github_repo
+
+        expect(WebMock).
+          to have_requested(:get, "http://registry.npmjs.org/@etag%2Fsomething")
+      end
+    end
   end
 end


### PR DESCRIPTION
Currently we blow up, which is sad. Prior art in `UpdateCheckers::JavaScript`, so this should be uncontroversial. See also https://github.com/yarnpkg/yarn/blob/aa800e0bc12b3a532beac544a97ba27254643f0f/src/registries/npm-registry.js#L49-L52