### PR TITLE
Look for JavaScript GitHub link in most recent releases first

### DIFF
--- a/lib/bump/dependency_metadata_finders/java_script.rb
+++ b/lib/bump/dependency_metadata_finders/java_script.rb
@@ -15,12 +15,16 @@ module Bump
         npm_url = "http://registry.npmjs.org/#{dependency.name}"
         npm_response =
           Excon.get(npm_url, middlewares: SharedHelpers.excon_middleware)
-        all_versions = JSON.parse(npm_response.body)["versions"]&.values
+
+        all_versions =
+          JSON.parse(npm_response.body)["versions"].
+          sort_by { |version, _| Gem::Version.new(version) }.
+          reverse
 
         potential_source_urls =
-          all_versions.map { |v| get_url(v.fetch("repository", {})) } +
-          all_versions.map { |v| v["homepage"] } +
-          all_versions.map { |v| get_url(v.fetch("bugs", {})) }
+          all_versions.map { |_, v| get_url(v.fetch("repository", {})) } +
+          all_versions.map { |_, v| v["homepage"] } +
+          all_versions.map { |_, v| get_url(v.fetch("bugs", {})) }
 
         potential_source_urls = potential_source_urls.compact
 

--- a/spec/dependency_metadata_finders/java_script_spec.rb
+++ b/spec/dependency_metadata_finders/java_script_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Bump::DependencyMetadataFinders::JavaScript do
     context "when there is a github link in the npm response" do
       let(:npm_response) { fixture("npm_response.json") }
 
-      it { is_expected.to eq("kesla/etag") }
+      it { is_expected.to eq("jshttp/etag") }
 
       it "caches the call to npm" do
         2.times { github_repo }
@@ -40,7 +40,7 @@ RSpec.describe Bump::DependencyMetadataFinders::JavaScript do
     context "when there's a link without the expected structure" do
       let(:npm_response) { fixture("npm_response_string_link.json") }
 
-      it { is_expected.to eq("kesla/etag") }
+      it { is_expected.to eq("jshttp/etag") }
 
       it "caches the call to npm" do
         2.times { github_repo }
@@ -70,7 +70,7 @@ RSpec.describe Bump::DependencyMetadataFinders::JavaScript do
           to_return(status: 200, body: npm_response)
       end
 
-      it { is_expected.to eq("kesla/etag") }
+      it { is_expected.to eq("jshttp/etag") }
     end
   end
 end


### PR DESCRIPTION
Previously we were looking at the oldest releases first. That's sad. Even our spec example had a different GitHub repo back in the day...!