### PR TITLE
Handle PR creation races gracefully

### DIFF
--- a/lib/bump/pull_request_creator.rb
+++ b/lib/bump/pull_request_creator.rb
@@ -17,7 +17,7 @@ module Bump
       return if branch_exists?
 
       commit = create_commit
-      create_branch(commit)
+      return unless create_branch(commit)
 
       create_pull_request
     end
@@ -65,6 +65,10 @@ module Bump
         "heads/#{new_branch_name}",
         commit.sha
       )
+    rescue Octokit::UnprocessableEntity => error
+      # Return quietly in the case of a race
+      return nil if error.message =~ /Reference already exists/
+      raise
     end
 
     def create_pull_request


### PR DESCRIPTION
If two processes are attempting to create identical PRs there is a race condition, which GitHub handles nicely for us by serving a `Reference already exists` error to us. It's fine for the losing party to just quietly return.