### PR TITLE
Allow a `pr_message_footer` argument to be passed to `PullRequestCreator`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,9 @@ Metrics/BlockLength:
   Exclude:
     - spec/**/*
 
+Metrics/ParameterLists:
+  Max: 10
+
 Style/EmptyLineAfterMagicComment:
   Enabled: false
 

--- a/lib/bump/pull_request_creator.rb
+++ b/lib/bump/pull_request_creator.rb
@@ -3,14 +3,17 @@ require "bump/dependency_metadata_finders"
 
 module Bump
   class PullRequestCreator
-    attr_reader :watched_repo, :dependency, :files, :base_commit, :github_client
+    attr_reader :watched_repo, :dependency, :files, :base_commit,
+                :github_client, :pr_message_footer
 
-    def initialize(repo:, base_commit:, dependency:, files:, github_client:)
+    def initialize(repo:, base_commit:, dependency:, files:, github_client:,
+                   pr_message_footer: nil)
       @dependency = dependency
       @watched_repo = repo
       @base_commit = base_commit
       @files = files
       @github_client = github_client
+      @pr_message_footer = pr_message_footer
     end
 
     def create
@@ -77,7 +80,7 @@ module Bump
         default_branch,
         new_branch_name,
         pr_name,
-        pr_message
+        pr_message_with_custom_footer
       )
     end
 
@@ -105,6 +108,11 @@ module Bump
       msg += "\n- [Changelog](#{changelog_url})" if changelog_url
       msg += "\n- [Commits](#{github_compare_url})" if github_compare_url
       msg
+    end
+
+    def pr_message_with_custom_footer
+      return pr_message unless pr_message_footer
+      pr_message + "\n\n#{pr_message_footer}"
     end
 
     def default_branch

--- a/spec/pull_request_creator_spec.rb
+++ b/spec/pull_request_creator_spec.rb
@@ -145,9 +145,8 @@ RSpec.describe Bump::PullRequestCreator do
     it "creates a PR with the right details" do
       creator.create
 
-      repo_url = "https://api.github.com/repos/gocardless/bump"
       expect(WebMock).
-        to have_requested(:post, "#{repo_url}/pulls").
+        to have_requested(:post, "#{watched_repo_url}/pulls").
         with(
           body: {
             base: "master",
@@ -208,6 +207,32 @@ RSpec.describe Bump::PullRequestCreator do
         creator.create
         expect(WebMock).
           to_not have_requested(:post, "#{watched_repo_url}/pulls")
+      end
+    end
+
+    context "with a custom footer" do
+      subject(:creator) do
+        Bump::PullRequestCreator.new(repo: repo,
+                                     base_commit: base_commit,
+                                     dependency: dependency,
+                                     files: files,
+                                     github_client: github_client,
+                                     pr_message_footer: "Example text")
+      end
+
+      it "includes the custom text in the PR message" do
+        creator.create
+
+        expect(WebMock).
+          to have_requested(:post, "#{watched_repo_url}/pulls").
+          with(
+            body: {
+              base: "master",
+              head: "bump_business_to_1.5.0",
+              title: "Bump business to 1.5.0",
+              body: /\n\nExample text/
+            }
+          )
       end
     end
   end


### PR DESCRIPTION
Sometimes, we want to mention things in the PR which are specific to the application using `bump-core`. For example, Dependabot will automatically keep your PRs conflict-free by rebasing them, will pause bumping (for a given version) when the PR is closed, and will listen for any feedback on the PR in the comments (and even have real humans reply-in).

Two options:
1) Allow integrators to completely overwrite the PR message
2) Allow integrators to add a footer to the PR message

I've gone for the later - I think we pretty much always want the rest of the PR in there, and for it to come first.