### PR TITLE
Move responsibility for getting dependency's true version to parser

### DIFF
--- a/lib/bump/dependency_file_parsers/base.rb
+++ b/lib/bump/dependency_file_parsers/base.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+module Bump
+  module DependencyFileParsers
+    class Base
+      attr_reader :dependency_files
+
+      def initialize(dependency_files:)
+        @dependency_files = dependency_files
+
+        required_files.each do |filename|
+          raise "No #{filename}!" unless get_original_file(filename)
+        end
+      end
+
+      def parse
+        raise NotImplementedError
+      end
+
+      private
+
+      def required_files
+        raise NotImplementedError
+      end
+
+      def get_original_file(filename)
+        dependency_files.find { |f| f.name == filename }
+      end
+    end
+  end
+end

--- a/lib/bump/dependency_file_parsers/java_script.rb
+++ b/lib/bump/dependency_file_parsers/java_script.rb
@@ -1,15 +1,12 @@
 # frozen_string_literal: true
 require "json"
 require "bump/dependency"
+require "bump/dependency_file_parsers/base"
+require "bump/dependency_file_fetchers/java_script"
 
 module Bump
   module DependencyFileParsers
-    class JavaScript
-      def initialize(dependency_files:)
-        @package_json = dependency_files.find { |f| f.name == "package.json" }
-        raise "No package.json!" unless @package_json
-      end
-
+    class JavaScript < Base
       def parse
         parsed_content = parser
 
@@ -32,8 +29,16 @@ module Bump
 
       private
 
+      def required_files
+        Bump::DependencyFileFetchers::JavaScript.required_files
+      end
+
+      def package_json
+        @package_json ||= get_original_file("package.json")
+      end
+
       def parser
-        JSON.parse(@package_json.content)
+        JSON.parse(package_json.content)
       end
     end
   end

--- a/lib/bump/dependency_file_parsers/java_script.rb
+++ b/lib/bump/dependency_file_parsers/java_script.rb
@@ -16,6 +16,11 @@ module Bump
         dependencies_hash = parsed_content["dependencies"] || {}
         dependencies_hash.merge!(parsed_content["devDependencies"] || {})
 
+        # TODO: Taking the version from the package.json file here is naive -
+        #       the version info found there is more likely in node-semver
+        #       format than the exact current version. In future we should
+        #       parse the yarn.lock file.
+
         dependencies_hash.map do |name, version|
           Dependency.new(
             name: name,

--- a/lib/bump/dependency_file_parsers/python.rb
+++ b/lib/bump/dependency_file_parsers/python.rb
@@ -1,19 +1,13 @@
 # frozen_string_literal: true
 require "bump/dependency"
+require "bump/dependency_file_parsers/base"
+require "bump/dependency_file_fetchers/python"
 
 module Bump
   module DependencyFileParsers
-    class Python
-      def initialize(dependency_files:)
-        @requirements = dependency_files.find do |f|
-          f.name == "requirements.txt"
-        end
-
-        raise "No requirements.txt!" unless @requirements
-      end
-
+    class Python < Base
       def parse
-        @requirements.
+        requirements.
           content.
           each_line.
           each_with_object([]) do |line, dependencies|
@@ -32,6 +26,16 @@ module Bump
               language: "python"
             )
           end
+      end
+
+      private
+
+      def required_files
+        Bump::DependencyFileFetchers::Python.required_files
+      end
+
+      def requirements
+        @requirements ||= get_original_file("requirements.txt")
       end
 
       class LineParser

--- a/lib/bump/dependency_file_parsers/ruby.rb
+++ b/lib/bump/dependency_file_parsers/ruby.rb
@@ -7,19 +7,25 @@ module Bump
     class Ruby
       def initialize(dependency_files:)
         @gemfile = dependency_files.find { |f| f.name == "Gemfile" }
+        @lockfile = dependency_files.find { |f| f.name == "Gemfile.lock" }
         raise "No Gemfile!" unless @gemfile
+        raise "No Gemfile.lock!" unless @lockfile
       end
 
       def parse
-        parser.dependencies.map do |dependency|
+        gemfile_parser.dependencies.map do |dependency|
           # Ignore dependencies with multiple requirements, since they would
-          # cause trouble at the gem update step
+          # cause trouble at the gem update step. TODO: fix!
           next if dependency.requirement.requirements.count > 1
 
-          version = dependency.requirement.to_s.match(/[\d\.]+/)[0]
+          # Ignore gems which appear in the Gemfile but not the Gemfile.lock.
+          # For instance, if a gem specifies `platform: [:windows]`, and the
+          # Gemfile.lock is generated on a Linux machine.
+          next if dependency_version(dependency.name).nil?
+
           Dependency.new(
             name: dependency.name,
-            version: version,
+            version: dependency_version(dependency.name).to_s,
             language: "ruby"
           )
         end.reject(&:nil?)
@@ -27,8 +33,28 @@ module Bump
 
       private
 
-      def parser
-        Gemnasium::Parser.gemfile(@gemfile.content)
+      attr_reader :gemfile, :lockfile
+
+      def gemfile_parser
+        Gemnasium::Parser.gemfile(gemfile.content)
+      end
+
+      # Parse the Gemfile.lock to get the gem version. Better than just relying
+      # on the dependency's specified version, which may have had a ~> matcher.
+      def dependency_version(dependency_name)
+        @parsed_lockfile ||= Bundler::LockfileParser.new(lockfile.content)
+
+        if dependency_name == "bundler"
+          return Gem::Version.new(Bundler::VERSION)
+        end
+
+        # The safe navigation operator is necessary because not all files in
+        # the Gemfile will appear in the Gemfile.lock. For instance, if a gem
+        # specifies `platform: [:windows]`, and the Gemfile.lock is generated
+        # on a Linux machine, the gem will be not appear in the lockfile.
+        @parsed_lockfile.specs.
+          find { |spec| spec.name == dependency_name }&.
+          version
       end
     end
   end

--- a/lib/bump/dependency_file_parsers/ruby.rb
+++ b/lib/bump/dependency_file_parsers/ruby.rb
@@ -1,17 +1,12 @@
 # frozen_string_literal: true
 require "gemnasium/parser"
 require "bump/dependency"
+require "bump/dependency_file_parsers/base"
+require "bump/dependency_file_fetchers/ruby"
 
 module Bump
   module DependencyFileParsers
-    class Ruby
-      def initialize(dependency_files:)
-        @gemfile = dependency_files.find { |f| f.name == "Gemfile" }
-        @lockfile = dependency_files.find { |f| f.name == "Gemfile.lock" }
-        raise "No Gemfile!" unless @gemfile
-        raise "No Gemfile.lock!" unless @lockfile
-      end
-
+    class Ruby < Base
       def parse
         gemfile_parser.dependencies.map do |dependency|
           # Ignore dependencies with multiple requirements, since they would
@@ -34,6 +29,18 @@ module Bump
       private
 
       attr_reader :gemfile, :lockfile
+
+      def required_files
+        Bump::DependencyFileFetchers::Ruby.required_files
+      end
+
+      def gemfile
+        @gemfile ||= get_original_file("Gemfile")
+      end
+
+      def lockfile
+        @lockfile ||= get_original_file("Gemfile.lock")
+      end
 
       def gemfile_parser
         Gemnasium::Parser.gemfile(gemfile.content)

--- a/lib/bump/update_checkers/base.rb
+++ b/lib/bump/update_checkers/base.rb
@@ -12,24 +12,19 @@ module Bump
       end
 
       def needs_update?
-        return false if dependency_version.nil?
-        Gem::Version.new(latest_version) > dependency_version
+        latest_version > Gem::Version.new(dependency.version)
       end
 
       def updated_dependency
         Dependency.new(
           name: dependency.name,
-          version: latest_version,
-          previous_version: dependency_version.to_s,
+          version: latest_version.to_s,
+          previous_version: dependency.version,
           language: dependency.language
         )
       end
 
       def latest_version
-        raise NotImplementedError
-      end
-
-      def dependency_version
         raise NotImplementedError
       end
     end

--- a/lib/bump/update_checkers/java_script.rb
+++ b/lib/bump/update_checkers/java_script.rb
@@ -1,32 +1,24 @@
 # frozen_string_literal: true
-require "json"
 require "excon"
 require "bump/update_checkers/base"
-require "bump/shared_helpers"
 
 module Bump
   module UpdateCheckers
     class JavaScript < Base
       def latest_version
-        @latest_version ||=
-          begin
-            npm_response = Excon.get(
-              dependency_url,
-              middlewares: SharedHelpers.excon_middleware
-            )
-
-            JSON.parse(npm_response.body)["dist-tags"]["latest"]
-          end
-      end
-
-      # TODO: Parsing the package.json file here is naive - the version info
-      #       found there is more likely in node-semver format than the exact
-      #       current version. In future we should parse the yarn.lock file.
-      def dependency_version
-        Gem::Version.new(dependency.version)
+        @latest_version ||= Gem::Version.new(fetch_latest_version)
       end
 
       private
+
+      def fetch_latest_version
+        npm_response = Excon.get(
+          dependency_url,
+          middlewares: SharedHelpers.excon_middleware
+        )
+
+        JSON.parse(npm_response.body)["dist-tags"]["latest"]
+      end
 
       def dependency_url
         # NPM registry expects slashes to be escaped

--- a/lib/bump/update_checkers/python.rb
+++ b/lib/bump/update_checkers/python.rb
@@ -1,25 +1,23 @@
 # frozen_string_literal: true
 require "excon"
 require "bump/update_checkers/base"
-require "bump/shared_helpers"
 
 module Bump
   module UpdateCheckers
     class Python < Base
       def latest_version
-        @latest_version ||=
-          begin
-            pypi_response = Excon.get(
-              dependency_url,
-              middlewares: SharedHelpers.excon_middleware
-            )
-
-            JSON.parse(pypi_response.body)["info"]["version"]
-          end
+        @latest_version ||= Gem::Version.new(fetch_latest_version)
       end
 
-      def dependency_version
-        Gem::Version.new(dependency.version)
+      private
+
+      def fetch_latest_version
+        pypi_response = Excon.get(
+          dependency_url,
+          middlewares: SharedHelpers.excon_middleware
+        )
+
+        JSON.parse(pypi_response.body)["info"]["version"]
       end
 
       def dependency_url

--- a/spec/dependency_file_parsers/base_spec.rb
+++ b/spec/dependency_file_parsers/base_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+require "spec_helper"
+require "bump/dependency"
+require "bump/dependency_file"
+require "bump/dependency_file_parsers/base"
+
+RSpec.describe Bump::DependencyFileParsers::Base do
+  let(:child_class) do
+    Class.new(described_class) do
+      def required_files
+        ["Gemfile"]
+      end
+    end
+  end
+  let(:parser_instance) do
+    child_class.new(dependency_files: files)
+  end
+
+  let(:gemfile) do
+    Bump::DependencyFile.new(
+      content: "a",
+      name: "Gemfile",
+      directory: "/path/to"
+    )
+  end
+  let(:files) { [gemfile] }
+
+  describe ".new" do
+    subject { -> { parser_instance } }
+
+    context "when the required file is present" do
+      let(:files) { [gemfile] }
+      it { is_expected.to_not raise_error }
+    end
+
+    context "when the required file is missing" do
+      let(:files) { [] }
+      it { is_expected.to raise_error(/No Gemfile/) }
+    end
+  end
+
+  describe "#get_original_file" do
+    subject { parser_instance.send(:get_original_file, filename) }
+
+    context "when the requested file is present" do
+      let(:filename) { "Gemfile" }
+      it { is_expected.to eq(gemfile) }
+    end
+
+    context "when the requested file is not present" do
+      let(:filename) { "Unknown.file" }
+      it { is_expected.to be_nil }
+    end
+  end
+end

--- a/spec/dependency_file_parsers/java_script_spec.rb
+++ b/spec/dependency_file_parsers/java_script_spec.rb
@@ -2,14 +2,23 @@
 require "spec_helper"
 require "bump/dependency_file"
 require "bump/dependency_file_parsers/java_script"
+require_relative "./shared_examples_for_file_parsers"
 
 RSpec.describe Bump::DependencyFileParsers::JavaScript do
-  let(:files) { [package_json] }
+  it_behaves_like "a dependency file parser"
+
+  let(:files) { [package_json, lockfile] }
   let(:package_json) do
     Bump::DependencyFile.new(name: "package.json", content: package_json_body)
   end
+  let(:lockfile) do
+    Bump::DependencyFile.new(name: "yarn.lock", content: lockfile_body)
+  end
   let(:package_json_body) do
     fixture("javascript", "package_files", "package.json")
+  end
+  let(:lockfile_body) do
+    fixture("javascript", "package_files", "yarn.lock")
   end
   let(:parser) { described_class.new(dependency_files: files) }
 

--- a/spec/dependency_file_parsers/python_spec.rb
+++ b/spec/dependency_file_parsers/python_spec.rb
@@ -2,8 +2,11 @@
 require "spec_helper"
 require "bump/dependency_file"
 require "bump/dependency_file_parsers/python"
+require_relative "./shared_examples_for_file_parsers"
 
 RSpec.describe Bump::DependencyFileParsers::Python do
+  it_behaves_like "a dependency file parser"
+
   let(:files) { [requirements] }
   let(:requirements) do
     Bump::DependencyFile.new(

--- a/spec/dependency_file_parsers/ruby_spec.rb
+++ b/spec/dependency_file_parsers/ruby_spec.rb
@@ -2,8 +2,11 @@
 require "spec_helper"
 require "bump/dependency_file"
 require "bump/dependency_file_parsers/ruby"
+require_relative "./shared_examples_for_file_parsers"
 
 RSpec.describe Bump::DependencyFileParsers::Ruby do
+  it_behaves_like "a dependency file parser"
+
   let(:files) { [gemfile, lockfile] }
   let(:gemfile) do
     Bump::DependencyFile.new(name: "Gemfile", content: gemfile_content)

--- a/spec/dependency_file_parsers/shared_examples_for_file_parsers.rb
+++ b/spec/dependency_file_parsers/shared_examples_for_file_parsers.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+require "spec_helper"
+require "octokit"
+require "bump/repo"
+require "bump/dependency_file_parsers/base"
+
+RSpec.shared_examples "a dependency file parser" do
+  describe "the class" do
+    subject { described_class }
+    let(:base_class) { Bump::DependencyFileParsers::Base }
+
+    its(:superclass) { is_expected.to eq(base_class) }
+
+    it "implements required_files" do
+      expect(described_class.private_instance_methods(false)).
+        to include(:required_files)
+    end
+
+    it "implements parse" do
+      expect(described_class.public_instance_methods).
+        to include(:parse)
+    end
+
+    it "doesn't define any additional public instance methods" do
+      expect(described_class.public_instance_methods).
+        to match_array(base_class.public_instance_methods)
+    end
+  end
+end

--- a/spec/fixtures/ruby/gemfiles/platform_windows
+++ b/spec/fixtures/ruby/gemfiles/platform_windows
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gem "business", "~> 1.4.0"
+gem "statesman", "~> 1.2.0", platform: [:mswin]

--- a/spec/fixtures/ruby/lockfiles/development_dependencies.lock
+++ b/spec/fixtures/ruby/lockfiles/development_dependencies.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     business (1.4.0)
-    statesman (1.2.1)
+    statesman (1.2.5)
 
 PLATFORMS
   ruby
@@ -10,7 +10,6 @@ PLATFORMS
 DEPENDENCIES
   business (~> 1.4.0)
   statesman (~> 1.2.0)
-  bundler (~> 1.10.5)
 
 BUNDLED WITH
-   1.10.6
+   1.14.6

--- a/spec/fixtures/ruby/lockfiles/platform_windows.lock
+++ b/spec/fixtures/ruby/lockfiles/platform_windows.lock
@@ -1,0 +1,14 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    business (1.4.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  business (~> 1.4.0)
+  statesman (~> 1.2.0)
+
+BUNDLED WITH
+   1.14.6

--- a/spec/fixtures/ruby/lockfiles/version_not_specified.lock
+++ b/spec/fixtures/ruby/lockfiles/version_not_specified.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    business (1.4.0)
+    statesman (1.2.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  business
+  statesman
+
+BUNDLED WITH
+   1.14.6

--- a/spec/update_checkers/java_script_spec.rb
+++ b/spec/update_checkers/java_script_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Bump::UpdateCheckers::JavaScript do
 
   describe "#latest_version" do
     subject { checker.latest_version }
-    it { is_expected.to eq("1.7.0") }
+    it { is_expected.to eq(Gem::Version.new("1.7.0")) }
 
     context "when the npm link resolves to a redirect" do
       let(:redirect_url) { "http://registry.npmjs.org/eTag" }
@@ -67,7 +67,7 @@ RSpec.describe Bump::UpdateCheckers::JavaScript do
           to_return(status: 200, body: fixture("npm_response.json"))
       end
 
-      it { is_expected.to eq("1.7.0") }
+      it { is_expected.to eq(Gem::Version.new("1.7.0")) }
     end
   end
 end

--- a/spec/update_checkers/python_spec.rb
+++ b/spec/update_checkers/python_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Bump::UpdateCheckers::Python do
 
   describe "#latest_version" do
     subject { checker.latest_version }
-    it { is_expected.to eq("2.6.0") }
+    it { is_expected.to eq(Gem::Version.new("2.6.0")) }
 
     context "when the pypi link resolves to a redirect" do
       let(:redirect_url) { "https://pypi.python.org/pypi/LuiGi/json" }
@@ -56,7 +56,7 @@ RSpec.describe Bump::UpdateCheckers::Python do
           to_return(status: 200, body: pypi_response)
       end
 
-      it { is_expected.to eq("2.6.0") }
+      it { is_expected.to eq(Gem::Version.new("2.6.0")) }
     end
   end
 


### PR DESCRIPTION
Spring clean to remove need for `UpdateCheckers` to re-compute the dependency version.