### PR TITLE
Remove unused spec setup

### DIFF
--- a/bump-core.gemspec
+++ b/bump-core.gemspec
@@ -31,6 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.5.0"
   spec.add_development_dependency "rspec-its", "~> 1.2.0"
   spec.add_development_dependency "rubocop", "~> 0.48.0"
-  spec.add_development_dependency "dotenv"
   spec.add_development_dependency "rake"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 require "rspec/its"
 require "webmock/rspec"
-require "dotenv"
-
-Dotenv.load(File.expand_path("../../config/dummy_env", __FILE__))
-
-$LOAD_PATH.unshift File.expand_path("../lib", __FILE__)
-require "bump"
 
 RSpec.configure do |config|
   config.color = true


### PR DESCRIPTION
Hangover from when `bump-core` was part of [bump](https://github.com/gocardless/bump).