### PR TITLE
Raise Bump::VersionConflict when a conflict prevents us getting a gem version

### DIFF
--- a/lib/bump/update_checkers/ruby.rb
+++ b/lib/bump/update_checkers/ruby.rb
@@ -42,6 +42,8 @@ module Bump
 
       def handle_bundler_errors(error)
         case error.error_class
+        when "Bundler::VersionConflict"
+          raise Bump::VersionConflict
         when "Bundler::Dsl::DSLError"
           msg = error.error_class + " with message: " + error.error_message
           raise Bump::DependencyFileNotEvaluatable, msg


### PR DESCRIPTION
This shouldn't really happen, but it does.

If a Gemfile.lock is wonky (because it's been manually edited) we could get a `Bundler::VersionConflict` when looking for the latest resolvable version of a gem. We could also in theory get it when resolving a gem that used to be a beta version. However, the most likely time to get it is when Bundler has a bug, like https://github.com/bundler/bundler/issues/5031.