### PR TITLE
Use git folders for branch names, and namespace under language and directory

### DIFF
--- a/lib/bump/dependency_file_parsers/ruby.rb
+++ b/lib/bump/dependency_file_parsers/ruby.rb
@@ -23,7 +23,7 @@ module Bump
             version: dependency_version(dependency.name).to_s,
             language: "ruby"
           )
-        end.reject(&:nil?)
+        end.compact
       end
 
       private

--- a/lib/bump/dependency_metadata_finders/python.rb
+++ b/lib/bump/dependency_metadata_finders/python.rb
@@ -14,7 +14,7 @@ module Bump
           pypi_listing.dig("info", "bugtrack_url"),
           pypi_listing.dig("info", "download_url"),
           pypi_listing.dig("info", "docs_url")
-        ].reject(&:nil?)
+        ].compact
 
         source_url = potential_source_urls.find { |url| url =~ GITHUB_REGEX }
 

--- a/lib/bump/pull_request_creator.rb
+++ b/lib/bump/pull_request_creator.rb
@@ -120,7 +120,7 @@ module Bump
     end
 
     def new_branch_name
-      path = ["bump", dependency.language, files.first.directory].reject(&:nil?)
+      path = ["bump", dependency.language, files.first.directory].compact
       File.join(*path, "bump_#{dependency.name}_to_#{dependency.version}")
     end
 

--- a/lib/bump/pull_request_creator.rb
+++ b/lib/bump/pull_request_creator.rb
@@ -120,7 +120,8 @@ module Bump
     end
 
     def new_branch_name
-      "bump_#{dependency.name}_to_#{dependency.version}"
+      path = ["bump", dependency.language, files.first.directory].reject(&:nil?)
+      File.join(*path, "bump_#{dependency.name}_to_#{dependency.version}")
     end
 
     def release_url

--- a/spec/pull_request_creator_spec.rb
+++ b/spec/pull_request_creator_spec.rb
@@ -29,21 +29,21 @@ RSpec.describe Bump::PullRequestCreator do
     Bump::DependencyFile.new(
       name: "Gemfile",
       content: fixture("ruby", "gemfiles", "Gemfile"),
-      directory: "files/are/here"
+      directory: "directory"
     )
   end
   let(:gemfile_lock) do
     Bump::DependencyFile.new(
       name: "Gemfile.lock",
       content: fixture("ruby", "lockfiles", "Gemfile.lock"),
-      directory: "files/are/here"
+      directory: "directory"
     )
   end
 
   let(:json_header) { { "Content-Type" => "application/json" } }
   let(:watched_repo_url) { "https://api.github.com/repos/#{repo}" }
   let(:business_repo_url) { "https://api.github.com/repos/gocardless/business" }
-  let(:branch_name) { "bump_business_to_1.5.0" }
+  let(:branch_name) { "bump/ruby/directory/bump_business_to_1.5.0" }
 
   before do
     stub_request(:get, watched_repo_url).
@@ -101,13 +101,13 @@ RSpec.describe Bump::PullRequestCreator do
                base_tree: "basecommitsha",
                tree: [
                  {
-                   path: "files/are/here/Gemfile",
+                   path: "directory/Gemfile",
                    mode: "100644",
                    type: "blob",
                    content: fixture("ruby", "gemfiles", "Gemfile")
                  },
                  {
-                   path: "files/are/here/Gemfile.lock",
+                   path: "directory/Gemfile.lock",
                    mode: "100644",
                    type: "blob",
                    content: fixture("ruby", "lockfiles", "Gemfile.lock")
@@ -137,7 +137,7 @@ RSpec.describe Bump::PullRequestCreator do
       expect(WebMock).
         to have_requested(:post, "#{watched_repo_url}/git/refs").
         with(body: {
-               ref: "refs/heads/bump_business_to_1.5.0",
+               ref: "refs/heads/bump/ruby/directory/bump_business_to_1.5.0",
                sha: "7638417db6d59f3c431d3e1f261cc637155684cd"
              })
     end
@@ -150,7 +150,7 @@ RSpec.describe Bump::PullRequestCreator do
         with(
           body: {
             base: "master",
-            head: "bump_business_to_1.5.0",
+            head: "bump/ruby/directory/bump_business_to_1.5.0",
             title: "Bump business to 1.5.0",
             body: "Bumps [business](https://github.com/gocardless/business) "\
                   "from 1.4.0 to 1.5.0.\n- [Release notes]"\
@@ -228,7 +228,7 @@ RSpec.describe Bump::PullRequestCreator do
           with(
             body: {
               base: "master",
-              head: "bump_business_to_1.5.0",
+              head: "bump/ruby/directory/bump_business_to_1.5.0",
               title: "Bump business to 1.5.0",
               body: /\n\nExample text/
             }


### PR DESCRIPTION
In theory, Bump could be running for multiple languages, and on multiple project directories, for the same repo. At the moment, that would cause lots of collisions in branch names.

This PR updates the Bump branch naming strategy to use git folders (rather than underscores) and namespace everything under `bump/<language>/[<directory>/]`.