### PR TITLE
Includes details of the directory (if present) in the PR name

### DIFF
--- a/lib/bump/pull_request_creator.rb
+++ b/lib/bump/pull_request_creator.rb
@@ -89,7 +89,10 @@ module Bump
     end
 
     def pr_name
-      "Bump #{dependency.name} to #{dependency.version}"
+      base = "Bump #{dependency.name} to #{dependency.version}"
+      return base if files.first.directory == "/"
+
+      base + " in #{files.first.directory}"
     end
 
     def pr_message


### PR DESCRIPTION
Will make PRs less confusing for anyone with sub-directories. Won't affect the usual use case of dependency files living in the root directory.