### PR TITLE
Consider resolvability when calculating latest_version (Cocoa)

### DIFF
--- a/lib/bump/update_checkers/cocoa.rb
+++ b/lib/bump/update_checkers/cocoa.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 require "cocoapods"
+require "gemnasium/parser"
 require "bump/update_checkers/base"
 require "bump/shared_helpers"
 require "bump/errors"
+require "bump/dependency_file_updaters/cocoa"
 
 module Bump
   module UpdateCheckers
@@ -19,20 +21,37 @@ module Bump
 
         return nil if pod.external_source
 
-        source_manager = Pod::Config.instance.sources_manager
-        analyzer = Pod::Installer::Analyzer.new(nil, parsed_podfile, nil)
-        analyzer.config.silent = true
-        analyzer.update_repositories
+        specs = pod_analyzer.analyze.specifications
 
-        sources =
-          if pod.podspec_repo
-            [source_manager.find_or_create_source_with_url(pod.podspec_repo)]
-          else
-            analyzer.sources
+        Gem::Version.new(specs.find { |d| d.name == dependency.name }.version)
+      end
+
+      def pod_analyzer
+        @pod_analyzer =
+          begin
+            lockfile_hash =
+              Pod::YAMLHelper.load_string(lockfile_for_update_check)
+            parsed_lockfile = Pod::Lockfile.new(lockfile_hash)
+
+            evaluated_podfile =
+              Pod::Podfile.from_ruby(nil, podfile_for_update_check)
+
+            pod_sandbox = Pod::Sandbox.new("tmp")
+
+            analyzer = Pod::Installer::Analyzer.new(
+              pod_sandbox,
+              evaluated_podfile,
+              parsed_lockfile
+            )
+
+            analyzer.installation_options.integrate_targets = false
+            analyzer.update = { pods: ["Alamofire"] }
+
+            analyzer.config.silent = true
+            analyzer.update_repositories
+
+            analyzer
           end
-
-        set = Pod::Specification::Set.new(pod.name, sources)
-        Gem::Version.new(set.highest_version)
       end
 
       def lockfile
@@ -45,6 +64,42 @@ module Bump
         podfile = dependency_files.find { |f| f.name == "Podfile" }
         raise "No Podfile!" unless podfile
         podfile
+      end
+
+      def podfile_for_update_check
+        podfile_content = podfile.content
+        podfile_content = remove_dependency_requirement(podfile_content)
+        prepend_git_auth_details(podfile_content)
+      end
+
+      def lockfile_for_update_check
+        lockfile_content = lockfile.content
+        prepend_git_auth_details(lockfile_content)
+      end
+
+      # Replace the original pod requirements with nothing, to fully "unlock"
+      # the pod during version checking
+      def remove_dependency_requirement(podfile_content)
+        podfile_content.
+          to_enum(:scan, Bump::DependencyFileUpdaters::Cocoa::POD_CALL).
+          find { Regexp.last_match[:name] == dependency.name }
+
+        original_pod_declaration_string = Regexp.last_match.to_s
+        updated_pod_declaration_string =
+          original_pod_declaration_string.
+          sub(/,[ \t]*#{Gemnasium::Parser::Patterns::REQUIREMENTS}/, "")
+
+        podfile_content.gsub(
+          original_pod_declaration_string,
+          updated_pod_declaration_string
+        )
+      end
+
+      def prepend_git_auth_details(podfile_content)
+        podfile_content.gsub(
+          "git@github.com:",
+          "https://#{github_access_token}:x-oauth-basic@github.com/"
+        )
       end
     end
   end

--- a/spec/fixtures/cocoa/lockfiles/version_conflict
+++ b/spec/fixtures/cocoa/lockfiles/version_conflict
@@ -1,0 +1,16 @@
+PODS:
+  - Alamofire (3.5.1)
+  - AlamofireImage (2.5.0):
+    - Alamofire (~> 3.5)
+
+DEPENDENCIES:
+  - Alamofire (~> 3.5.0)
+  - AlamofireImage (~> 2.5.0)
+
+SPEC CHECKSUMS:
+  Alamofire: 0dfba1184a543e2aa160f4e39cac4e8aba48d223
+  AlamofireImage: 2d34936e5201270bb17a316a786e90e83b4a249d
+
+PODFILE CHECKSUM: 35c9e7370620f5bfd2e280ac57915ae4f834119c
+
+COCOAPODS: 1.2.1

--- a/spec/fixtures/cocoa/podfiles/version_conflict
+++ b/spec/fixtures/cocoa/podfiles/version_conflict
@@ -1,0 +1,11 @@
+platform :ios, '9.0'
+use_frameworks!
+
+def core_pods
+  pod 'Alamofire', '~> 3.5.0'
+  pod 'AlamofireImage', '~> 2.5.0'
+end
+
+target 'MyApp' do
+  core_pods
+end

--- a/spec/update_checkers/cocoa_spec.rb
+++ b/spec/update_checkers/cocoa_spec.rb
@@ -40,9 +40,22 @@ RSpec.describe Bump::UpdateCheckers::Cocoa do
   describe "#latest_version" do
     subject { checker.latest_version }
 
-    # Stubbing the CocoaPods spec repo is hard. Instead just spec that the
-    # latest version is high
-    it { is_expected.to be >= Gem::Version.new("4.4.0") }
+    context "for a dependency from the master source" do
+      # Stubbing the CocoaPods spec repo is hard. Instead just spec that the
+      # latest version is high
+      it { is_expected.to be >= Gem::Version.new("4.4.0") }
+
+      context "with a version conflict at the latest version" do
+        let(:podfile_content) do
+          fixture("cocoa", "podfiles", "version_conflict")
+        end
+        let(:lockfile_content) do
+          fixture("cocoa", "lockfiles", "version_conflict")
+        end
+
+        it { is_expected.to eq(Gem::Version.new("3.5.1")) }
+      end
+    end
 
     context "for a dependency with a git source" do
       let(:podfile_content) { fixture("cocoa", "podfiles", "git_source") }
@@ -64,7 +77,7 @@ RSpec.describe Bump::UpdateCheckers::Cocoa do
       it { is_expected.to eq(Gem::Version.new("4.3.0")) }
     end
 
-    context "for a dependency with a specified source repo" do
+    context "for a dependency with a specified source repo (inline)" do
       before do
         specs_url =
           "https://api.github.com/repos/dependabot/Specs/commits/master"


### PR DESCRIPTION
Gives the CocoaPods update checker the same treatment as #35 gave the Ruby one. Includes feature spec. 🚀 