### PR TITLE
Ignore exotic JavaScript dependencies

### DIFF
--- a/helpers/javascript/test/fixtures/parser/package.json
+++ b/helpers/javascript/test/fixtures/parser/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "is-number": "https://github.com/jonschlinkert/is-number.git",
+    "is-promise": "file:/tmp/is-promise",
     "left-pad": "^1.1.0",
     "lodash": "^4.17.4"
   }

--- a/helpers/javascript/test/fixtures/parser/package.json
+++ b/helpers/javascript/test/fixtures/parser/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "is-number": "https://github.com/jonschlinkert/is-number.git",
     "left-pad": "^1.1.0",
     "lodash": "^4.17.4"
   }

--- a/helpers/javascript/test/fixtures/parser/yarn.lock
+++ b/helpers/javascript/test/fixtures/parser/yarn.lock
@@ -12,6 +12,9 @@ is-buffer@^1.1.5:
   dependencies:
     kind-of "^3.0.2"
 
+"is-promise@file:/tmp/is-promise":
+  version "2.1.0"
+
 kind-of@^3.0.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"

--- a/helpers/javascript/test/fixtures/parser/yarn.lock
+++ b/helpers/javascript/test/fixtures/parser/yarn.lock
@@ -2,6 +2,22 @@
 # yarn lockfile v1
 
 
+is-buffer@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.5.tgz#1f3b26ef613b214b88cbca23cc6c01d87961eecc"
+
+"is-number@https://github.com/jonschlinkert/is-number.git":
+  version "3.0.0"
+  resolved "https://github.com/jonschlinkert/is-number.git#af885e2e890b9ef0875edd2b117305119ee5bdc5"
+  dependencies:
+    kind-of "^3.0.2"
+
+kind-of@^3.0.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
+  dependencies:
+    is-buffer "^1.1.5"
+
 left-pad@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.1.1.tgz#ca566bbdd84b90cc5969ac1726fda51f9d936a3c"

--- a/helpers/javascript/test/parser.test.js
+++ b/helpers/javascript/test/parser.test.js
@@ -10,9 +10,14 @@ describe("parser", () => {
     );
   });
 
-  it("excludes 'exotic' dependencies (git, path, etc.)", async () => {
+  it("excludes git dependencies", async () => {
     const deps = await parser.parse(dir);
     expect(deps.map(d => d.name).sort()).not.toContain("is-number");
+  });
+
+  it("excludes path-based dependencies", async () => {
+    const deps = await parser.parse(dir);
+    expect(deps.map(d => d.name).sort()).not.toContain("is-promise");
   });
 
   it("gets the version from the yarn.lock, not the package.json", async () => {

--- a/helpers/javascript/test/parser.test.js
+++ b/helpers/javascript/test/parser.test.js
@@ -3,9 +3,16 @@ const parser = require("../lib/parser");
 describe("parser", () => {
   const dir = "test/fixtures/parser";
 
-  it("returns an entry for each dependency", async () => {
+  it("returns an entry for each npm dependency", async () => {
     const deps = await parser.parse(dir);
-    expect(deps.length).toEqual(2);
+    expect(deps.map(d => d.name).sort()).toEqual(
+      expect.arrayContaining(["left-pad", "lodash"])
+    );
+  });
+
+  it("excludes 'exotic' dependencies (git, path, etc.)", async () => {
+    const deps = await parser.parse(dir);
+    expect(deps.map(d => d.name).sort()).not.toContain("is-number");
   });
 
   it("gets the version from the yarn.lock, not the package.json", async () => {


### PR DESCRIPTION
This prevents us from trying to update git and path-based dependencies.

We do this for other languages, and until we've got a good strategy for handling exotic dependencies, we should ignore them rather than trying and failing to do an update.

In due course this could be moved into an update checker, as that's where this check is done in Ruby. But first, we'd need a native JS update checker...