### PR TITLE
Move Ruby resolvability handling into UpdateChecker, and handle yanked gems

### DIFF
--- a/lib/bump/errors.rb
+++ b/lib/bump/errors.rb
@@ -5,6 +5,7 @@ module Bump
 
   class VersionConflict < BumpError; end
   class DependencyFileNotEvaluatable < BumpError; end
+  class DependencyFileNotResolvable < BumpError; end
 
   class DependencyFileNotFound < BumpError
     attr_reader :file_path

--- a/lib/bump/file_updaters/ruby/bundler.rb
+++ b/lib/bump/file_updaters/ruby/bundler.rb
@@ -83,20 +83,6 @@ module Bump
               end
             end
           post_process_lockfile(lockfile_body)
-        rescue SharedHelpers::ChildProcessFailed => error
-          handle_bundler_errors(error)
-        end
-
-        def handle_bundler_errors(error)
-          case error.error_class
-          when "Bundler::VersionConflict"
-            raise Bump::VersionConflict
-          when "Bundler::Source::Git::GitCommandError"
-            command = error.message.match(GIT_COMMAND_ERROR_REGEX)[:command]
-            raise Bump::GitCommandError, command
-          else
-            raise
-          end
         end
 
         def write_temporary_dependency_files_to(dir)

--- a/spec/fixtures/ruby/lockfiles/yanked_gem.lock
+++ b/spec/fixtures/ruby/lockfiles/yanked_gem.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    business (1.4.1)
+    statesman (1.2.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  business (~> 1.4.0)
+  statesman (~> 1.2.0)
+
+BUNDLED WITH
+   1.10.6


### PR DESCRIPTION
Previously, we were handling Bundler resolvability errors in both the UpdateChecker and the DependencyFileUpdater. That's duplicative and unnecessary since any resolvability errors will manifest at update checking time (since we now have #35).

We were also not handling the case of yanked or non-existent gems. These need exactly the same treatment as Gemfiles with a version conflict in them - both are cases of a Gemfile not being resolvable. As such, I've created a new error class: `Bump::DependencyFileNotResolvable`

Note that the removal of `Bump::VersionConflict` is breaking - applications just need to replace any handling of that exception with the same treatment for `Bump::DependencyFileNotResolvable`. I think it's worth killing that old error class all the same - error handling was getting out of control.