### PR TITLE
Make yarn run in non-interactive mode

### DIFF
--- a/helpers/javascript/lib/updater.js
+++ b/helpers/javascript/lib/updater.js
@@ -15,7 +15,7 @@ const fs = require("fs");
 const path = require("path");
 const { Add } = require("yarn/lib/cli/commands/add");
 const Config = require("yarn/lib/config").default;
-const { NoopReporter } = require("yarn/lib/reporters");
+const { EventReporter } = require("yarn/lib/reporters");
 const Lockfile = require("yarn/lib/lockfile/wrapper").default;
 
 // Add is a subclass of the Install CLI command, which is responsible for
@@ -78,9 +78,9 @@ async function updateDependencyFiles(directory, depName, desiredVersion) {
   const originalYarnLock = readFile("yarn.lock");
 
   const flags = { ignoreScripts: true };
-  const reporter = new NoopReporter();
+  const reporter = new EventReporter();
   const config = new Config(reporter);
-  await config.init({ cwd: directory });
+  await config.init({ cwd: directory, nonInteractive: true });
 
   // Find the old dependency pattern from the package.json, so we can construct
   // a new pattern that contains the new version but maintains the old format

--- a/helpers/javascript/test/updater.test.js
+++ b/helpers/javascript/test/updater.test.js
@@ -49,4 +49,16 @@ describe("updater", () => {
     expect(result["yarn.lock"]).not.toContain("\n# yarn v");
     expect(result["yarn.lock"]).not.toContain("\n# node");
   });
+
+  it("doesn't show an interactive prompt when resolution fails", async () => {
+    await copyDependencies("original", tempDir);
+
+    expect.assertions(1);
+    try {
+      // Change this test if left-pad ever reaches v99.99.99
+      await updateDependencyFiles(tempDir, "left-pad", "99.99.99");
+    } catch (error) {
+      expect(error).not.toBeNull();
+    }
+  });
 });


### PR DESCRIPTION
Currently if resolution fails, it'll show a list of versions, and hang until you choose one. Bump runs on servers so that's silly.