### PR TITLE
Add support for Elixir [WIP]

### DIFF
--- a/helpers/elixir/bin/run.exs
+++ b/helpers/elixir/bin/run.exs
@@ -1,0 +1,1 @@
+% TODO: Write some Elixir code here. See JavaScript and PHP examples.

--- a/lib/bump/file_fetchers.rb
+++ b/lib/bump/file_fetchers.rb
@@ -2,6 +2,7 @@
 require "bump/file_fetchers/ruby/bundler"
 require "bump/file_fetchers/python/pip"
 require "bump/file_fetchers/java_script/yarn"
+require "bump/file_fetchers/elixir/hex"
 
 module Bump
   module FileFetchers
@@ -10,6 +11,7 @@ module Bump
       when "bundler" then FileFetchers::Ruby::Bundler
       when "yarn" then FileFetchers::JavaScript::Yarn
       when "pip" then FileFetchers::Python::Pip
+      when "hex_elixir" then FileFetchers::Elixir::Hex
       else raise "Unsupported package_manager #{package_manager}"
       end
     end

--- a/lib/bump/file_fetchers/elixir/hex.rb
+++ b/lib/bump/file_fetchers/elixir/hex.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+require "bump/file_fetchers/base"
+
+module Bump
+  module FileFetchers
+    module Elixir
+      class Hex < Bump::FileFetchers::Base
+        def self.required_files
+          %w(mix.exs mix.lock)
+        end
+      end
+    end
+  end
+end

--- a/lib/bump/file_parsers.rb
+++ b/lib/bump/file_parsers.rb
@@ -2,6 +2,7 @@
 require "bump/file_parsers/ruby/bundler"
 require "bump/file_parsers/python/pip"
 require "bump/file_parsers/java_script/yarn"
+require "bump/file_parsers/elixir/hex"
 
 module Bump
   module FileParsers
@@ -10,6 +11,7 @@ module Bump
       when "bundler" then FileParsers::Ruby::Bundler
       when "yarn" then FileParsers::JavaScript::Yarn
       when "pip" then FileParsers::Python::Pip
+      when "hex_elixir" then FileParsers::Elixir::Hex
       else raise "Unsupported package_manager #{package_manager}"
       end
     end

--- a/lib/bump/file_parsers/elixir/hex.rb
+++ b/lib/bump/file_parsers/elixir/hex.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+require "bump/dependency"
+require "bump/file_parsers/base"
+require "bump/file_fetchers/elixir/hex"
+require "bump/shared_helpers"
+
+module Bump
+  module FileParsers
+    module Elixir
+      class Hex < Bump::FileParsers::Base
+        def parse
+          dependency_versions.map do |dep|
+            Dependency.new(
+              name: dep["name"],
+              version: dep["version"],
+              language: "elixir"
+            )
+          end
+        end
+
+        private
+
+        def dependency_versions
+          SharedHelpers.in_a_temporary_directory do |dir|
+            File.write(File.join(dir, "mix.exs"), mixfile.content)
+            File.write(File.join(dir, "mix.lock"), lockfile.content)
+
+            SharedHelpers.run_helper_subprocess(
+              command: "elixir #{elixir_helper_path}",
+              function: "parse",
+              args: [dir]
+            )
+          end
+        end
+
+        def elixir_helper_path
+          project_root = File.join(File.dirname(__FILE__), "../../../..")
+          File.join(project_root, "helpers/elixir/bin/run.exs")
+        end
+
+        def required_files
+          Bump::FileFetchers::Elixir::Hex.required_files
+        end
+
+        def mixfile
+          @mixfile ||= get_original_file("mix.exs")
+        end
+
+        def lockfile
+          @lockfile ||= get_original_file("mix.lock")
+        end
+      end
+    end
+  end
+end

--- a/spec/bump/file_fetchers/elixir/hex_spec.rb
+++ b/spec/bump/file_fetchers/elixir/hex_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+require "bump/file_fetchers/elixir/hex"
+require_relative "../shared_examples_for_file_fetchers"
+
+RSpec.describe Bump::FileFetchers::Elixir::Hex do
+  it_behaves_like "a dependency file fetcher"
+end

--- a/spec/bump/file_parsers/elixir/hex_spec.rb
+++ b/spec/bump/file_parsers/elixir/hex_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+require "spec_helper"
+require "bump/dependency_file"
+require "bump/file_parsers/elixir/hex"
+require_relative "../shared_examples_for_file_parsers"
+
+RSpec.describe Bump::FileParsers::Elixir::Hex do
+  it_behaves_like "a dependency file parser"
+
+  let(:files) { [mixfile, lockfile] }
+  let(:mixfile) do
+    Bump::DependencyFile.new(name: "mix.exs", content: mixfile_body)
+  end
+  let(:lockfile) do
+    Bump::DependencyFile.new(name: "mix.lock", content: lockfile_body)
+  end
+  let(:mixfile_body) { fixture("elixir", "mixfiles", "mix.exs") }
+  let(:lockfile_body) { fixture("elixir", "lockfiles", "mix.lock") }
+  let(:parser) { described_class.new(dependency_files: files) }
+
+  pending "parse" do
+    subject(:dependencies) { parser.parse }
+
+    its(:length) { is_expected.to eq(6) }
+
+    context "with a version specified" do
+      describe "the first dependency" do
+        subject { dependencies.first }
+
+        it { is_expected.to be_a(Bump::Dependency) }
+        its(:name) { is_expected.to eq("phoenix") }
+        its(:version) { is_expected.to eq("1.2.4") }
+      end
+    end
+  end
+end

--- a/spec/fixtures/elixir/lockfiles/minor_version_specified
+++ b/spec/fixtures/elixir/lockfiles/minor_version_specified
@@ -1,0 +1,12 @@
+%{"cowboy": {:hex, :cowboy, "1.1.2", "61ac29ea970389a88eca5a65601460162d370a70018afe6f949a29dca91f3bb0", [:rebar3], [{:cowlib, "~> 1.0.2", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.3.2", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
+  "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], [], "hexpm"},
+  "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], [], "hexpm"},
+  "gettext": {:hex, :gettext, "0.13.1", "5e0daf4e7636d771c4c71ad5f3f53ba09a9ae5c250e1ab9c42ba9edccc476263", [:mix], [], "hexpm"},
+  "mime": {:hex, :mime, "1.1.0", "01c1d6f4083d8aa5c7b8c246ade95139620ef8effb009edde934e0ec3b28090a", [:mix], [], "hexpm"},
+  "phoenix": {:hex, :phoenix, "1.2.4", "4172479b5e21806a5e4175b54820c239e0d4effb0b07912e631aa31213a05bae", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, repo: "hexpm", optional: true]}, {:phoenix_pubsub, "~> 1.0", [hex: :phoenix_pubsub, repo: "hexpm", optional: false]}, {:plug, "~> 1.4 or ~> 1.3.3 or ~> 1.2.4 or ~> 1.1.8 or ~> 1.0.5", [hex: :plug, repo: "hexpm", optional: false]}, {:poison, "~> 1.5 or ~> 2.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
+  "phoenix_html": {:hex, :phoenix_html, "2.9.3", "1b5a2122cbf743aa242f54dced8a4f1cc778b8bd304f4b4c0043a6250c58e258", [:mix], [{:plug, "~> 1.0", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
+  "phoenix_live_reload": {:hex, :phoenix_live_reload, "1.0.8", "4333f9c74190f485a74866beff2f9304f069d53f047f5fbb0fb8d1ee4c495f73", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, repo: "hexpm", optional: false]}, {:phoenix, "~> 1.0 or ~> 1.2-rc", [hex: :phoenix, repo: "hexpm", optional: false]}], "hexpm"},
+  "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.1", "c10ddf6237007c804bf2b8f3c4d5b99009b42eca3a0dfac04ea2d8001186056a", [:mix], [], "hexpm"},
+  "plug": {:hex, :plug, "1.3.5", "7503bfcd7091df2a9761ef8cecea666d1f2cc454cbbaf0afa0b6e259203b7031", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
+  "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], [], "hexpm"},
+  "ranch": {:hex, :ranch, "1.3.2", "e4965a144dc9fbe70e5c077c65e73c57165416a901bd02ea899cfd95aa890986", [:rebar3], [], "hexpm"}}

--- a/spec/fixtures/elixir/mixfiles/minor_version_specified
+++ b/spec/fixtures/elixir/mixfiles/minor_version_specified
@@ -1,0 +1,38 @@
+defmodule Web.Mixfile do
+  use Mix.Project
+
+  def project do
+    [app: :web,
+     version: "0.0.1",
+     elixir: "~> 1.2",
+     elixirc_paths: elixirc_paths(Mix.env),
+     compilers: [:phoenix, :gettext] ++ Mix.compilers,
+     build_embedded: Mix.env == :prod,
+     start_permanent: Mix.env == :prod,
+     deps: deps()]
+  end
+
+  # Configuration for the OTP application.
+  #
+  # Type `mix help compile.app` for more information.
+  def application do
+    [mod: {Web, []},
+     applications: [:phoenix, :phoenix_pubsub, :phoenix_html, :cowboy, :logger, :gettext]]
+  end
+
+  # Specifies which paths to compile per environment.
+  defp elixirc_paths(:test), do: ["lib", "web", "test/support"]
+  defp elixirc_paths(_),     do: ["lib", "web"]
+
+  # Specifies your project dependencies.
+  #
+  # Type `mix help deps` for examples and options.
+  defp deps do
+    [{:phoenix, "~> 1.2"},
+     {:phoenix_pubsub, "~> 1.0"},
+     {:phoenix_html, "~> 2.6"},
+     {:phoenix_live_reload, "~> 1.0", only: :dev},
+     {:gettext, "~> 0.11"},
+     {:cowboy, "~> 1.0"}]
+  end
+end


### PR DESCRIPTION
A starting point for adding Elixir support.

Next step would be to write a parser for the `mix.lock` file, in Elixir. The [JavaScript helper run task](https://github.com/gocardless/bump-core/blob/master/helpers/javascript/bin/run.js) and [parser](https://github.com/gocardless/bump-core/blob/master/helpers/javascript/lib/parser.js) are the best places to start for understanding how shelling out to helpers works. We'll probably want to piggy back off of `Hex` as much as possible here, and include it as a dependency (like we do with Yarn).

Once an Elixir parser is written, the pending specs in `spec/bump/file_parsers/elixir/hex_spec.rb` should pass. At that point, let's talk about adding the `UpdateChecker`, `FileUpdater` and `MetadataFinder` classes.