### PR TITLE
Failing spec for prerelease version with a fourth position

### DIFF
--- a/helpers/javascript/lib/updater.js
+++ b/helpers/javascript/lib/updater.js
@@ -112,6 +112,7 @@ function updateVersionPattern(currentPattern, desiredVersion) {
     const oldParts = oldVersion.split(".");
     const newParts = desiredVersion.split(".");
     return oldParts
+      .slice(0, newParts.length)
       .map((part, i) => (part.match(/^x\b/) ? "x" : newParts[i]))
       .join(".");
   });

--- a/helpers/javascript/test/updater.test.js
+++ b/helpers/javascript/test/updater.test.js
@@ -79,7 +79,15 @@ describe("updateVersionPattern", () => {
     expect(updateVersionPattern("^1.2.3-rc1", "4.5.6")).toEqual("^4.5.6");
   });
 
+  it("handles pre-release versions using four places", () => {
+    expect(updateVersionPattern("^1.2.3.rc1", "4.5.6")).toEqual("^4.5.6");
+  });
+
   it("handles x.x versions", () => {
     expect(updateVersionPattern("^1.x.x-rc1", "4.5.6")).toEqual("^4.x.x");
+  });
+
+  it("handles x.x versions using four places", () => {
+    expect(updateVersionPattern("^1.x.x.rc1", "4.5.6")).toEqual("^4.x.x");
   });
 });

--- a/helpers/javascript/test/updater.test.js
+++ b/helpers/javascript/test/updater.test.js
@@ -71,6 +71,14 @@ describe("updateVersionPattern", () => {
     expect(updateVersionPattern("1.2.3", "4.5.6")).toEqual("4.5.6");
   });
 
+  it("handles unspecific patterns", () => {
+    expect(updateVersionPattern("1", "4.5.6")).toEqual("4");
+  });
+
+  it("handles unspecific versions", () => {
+    expect(updateVersionPattern("1.2.3", "4")).toEqual("4");
+  });
+
   it("handles caret versions", () => {
     expect(updateVersionPattern("^1.2.3", "4.5.6")).toEqual("^4.5.6");
   });


### PR DESCRIPTION
Needs an update to the processing in `javascript/lib/updater.js`.