### PR TITLE
Correctly list path-based dependencies

### DIFF
--- a/lib/bump/update_checkers/ruby/bundler.rb
+++ b/lib/bump/update_checkers/ruby/bundler.rb
@@ -94,7 +94,7 @@ module Bump
 
         def path_based_dependencies
           ::Bundler::LockfileParser.new(lockfile.content).specs.select do |spec|
-            spec.source.is_a?(::Bundler::Source::Path)
+            spec.source.instance_of?(::Bundler::Source::Path)
           end
         end
 

--- a/spec/bump/update_checkers/ruby/bundler_spec.rb
+++ b/spec/bump/update_checkers/ruby/bundler_spec.rb
@@ -119,7 +119,11 @@ RSpec.describe Bump::UpdateCheckers::Ruby::Bundler do
 
       it "raises a Bump::PathBasedDependencies error" do
         expect { checker.latest_version }.
-          to raise_error(Bump::PathBasedDependencies)
+          to raise_error(
+            Bump::PathBasedDependencies,
+            "Path based dependencies are not supported. " \
+            "Path based dependencies found: bump-core"
+          )
       end
 
       context "when Bundler raises a PathError but there are no path gems" do

--- a/spec/fixtures/ruby/gemfiles/path_source
+++ b/spec/fixtures/ruby/gemfiles/path_source
@@ -1,3 +1,5 @@
 source "https://rubygems.org"
 
+gem "hutch"
 gem "bump-core", path: "../bump-core"
+gem "prius", git: "https://github.com/gocardless/prius"

--- a/spec/fixtures/ruby/lockfiles/path_source.lock
+++ b/spec/fixtures/ruby/lockfiles/path_source.lock
@@ -1,7 +1,13 @@
+GIT
+  remote: https://github.com/gocardless/prius
+  revision: cff701b3bfb182afc99a85657d7c9f3d6c1ccce2
+  specs:
+    prius (1.0.0)
+
 PATH
   remote: ../bump-core
   specs:
-    bump-core (0.5.5)
+    bump-core (0.6.5)
       bundler (>= 1.12.0)
       excon (~> 0.55)
       gemnasium-parser (~> 0.1)
@@ -11,15 +17,34 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (5.1.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
-    excon (0.55.0)
+    amq-protocol (2.2.0)
+    bunny (2.7.0)
+      amq-protocol (>= 2.2.0)
+    carrot-top (0.0.7)
+      json
+    concurrent-ruby (1.0.5)
+    excon (0.57.1)
     faraday (0.12.1)
       multipart-post (>= 1.2, < 3)
     gemnasium-parser (0.1.9)
     gems (1.0.0)
       json
+    hutch (0.24.0)
+      activesupport (>= 4.2, < 6)
+      bunny (>= 2.6.3)
+      carrot-top (~> 0.0.7)
+      multi_json (~> 1.12)
+    i18n (0.8.4)
     json (2.1.0)
+    minitest (5.10.2)
+    multi_json (1.12.1)
     multipart-post (2.0.0)
     octokit (4.7.0)
       sawyer (~> 0.8.0, >= 0.5.3)
@@ -27,12 +52,17 @@ GEM
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
+    thread_safe (0.3.6)
+    tzinfo (1.2.3)
+      thread_safe (~> 0.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   bump-core!
+  hutch
+  prius!
 
 BUNDLED WITH
    1.15.0


### PR DESCRIPTION
When selecting the path-based dependencies we use `is_a?`, however,
since `Bundler::Source::Path` is a superclass of `Bundler::Source::Git`
this would incorrectly select git-based dependencies as well, this
replaces `is_a?` with `instance_of?` and adds the test data to cover the
case.

Will follow with: 

- [x] minor version bump
- [x] update changelog