### PR TITLE
Remove path-based dependencies from Gemfile

### DIFF
--- a/lib/bump/file_fetchers/ruby/bundler.rb
+++ b/lib/bump/file_fetchers/ruby/bundler.rb
@@ -8,6 +8,21 @@ module Bump
         def self.required_files
           %w(Gemfile Gemfile.lock)
         end
+
+        # We currently don't support path-based dependencies, so, we
+        # remove them from the Gemfile entirely.
+        #
+        # We'll resolve the Gemfile without a line (it'll be removed)
+        # from the file, which is not ideal but it'll at
+        # least allow us to resolve what needs to update as opposed
+        # to not resolving anything at all.
+        def files
+          super do |file_content|
+            file_content.lines.reject do |line|
+              line.include?("path")
+            end.join
+          end
+        end
       end
     end
   end

--- a/spec/bump/file_fetchers/base_spec.rb
+++ b/spec/bump/file_fetchers/base_spec.rb
@@ -36,6 +36,17 @@ RSpec.describe Bump::FileFetchers::Base do
 
       it { is_expected.to be_a(Bump::DependencyFile) }
       its(:content) { is_expected.to include("octokit") }
+
+      context "when a block is given" do
+        let(:files) do
+          file_fetcher_instance.files do |file_content|
+            file_content + " yielded"
+          end
+        end
+
+        it { is_expected.to be_a(Bump::DependencyFile) }
+        its(:content) { is_expected.to include("yielded") }
+      end
     end
 
     context "with a directory specified" do


### PR DESCRIPTION
We currently don't support path-based dependencies, so, we remove them from the Gemfile entirely.

We'll resolve the Gemfile without a line from the file which is not ideal, but, it'll at least allow us to resolve what needs to be updated as opposed to not resolving anything at all.

I genuinely think this a much better experience even if it seems like a temporary "hack", it allows to state "Hey, we don't support this type of dependency but here is our best effort on resolving the rest of your Gemfile", this will cause the maintainer of the repository to take manual action but won't completely halt `bump-core`. 