### PR TITLE
Allow Gemfiles with path dependencies

### DIFF
--- a/lib/bump/file_fetchers/base.rb
+++ b/lib/bump/file_fetchers/base.rb
@@ -18,9 +18,7 @@ module Bump
       end
 
       def files
-        @files ||= self.class.required_files.map do |name|
-          fetch_file_from_github(name)
-        end
+        @files ||= required_files + extra_files
       end
 
       def commit
@@ -29,6 +27,16 @@ module Bump
       end
 
       private
+
+      def required_files
+        @required_files ||= self.class.required_files.map do |name|
+          fetch_file_from_github(name)
+        end
+      end
+
+      def extra_files
+        []
+      end
 
       def fetch_file_from_github(file_name)
         file_path = File.join(directory, file_name)

--- a/lib/bump/file_fetchers/ruby/bundler.rb
+++ b/lib/bump/file_fetchers/ruby/bundler.rb
@@ -8,6 +8,27 @@ module Bump
         def self.required_files
           %w(Gemfile Gemfile.lock)
         end
+
+        private
+
+        def extra_files
+          lockfile = ::Bundler::LockfileParser.new(gemfile_lock)
+          path_specs = lockfile.specs.select do |spec|
+            spec.source.instance_of?(::Bundler::Source::Path)
+          end
+          path_specs.map do |spec|
+            dir, base = spec.source.path.split
+            file = File.join(dir, base, "#{base}.gemspec")
+            fetch_file_from_github(file)
+          end
+        end
+
+        def gemfile_lock
+          gemfile_lock = required_files.find do |file|
+            file.name == "Gemfile.lock"
+          end
+          gemfile_lock.content
+        end
       end
     end
   end

--- a/spec/bump/file_fetchers/ruby/bundler_spec.rb
+++ b/spec/bump/file_fetchers/ruby/bundler_spec.rb
@@ -4,4 +4,42 @@ require_relative "../shared_examples_for_file_fetchers"
 
 RSpec.describe Bump::FileFetchers::Ruby::Bundler do
   it_behaves_like "a dependency file fetcher"
+
+  let(:repo) { Bump::Repo.new(name: "gocardless/bump", commit: nil) }
+  let(:github_client) { Octokit::Client.new(access_token: "token") }
+  let(:file_fetcher_instance) do
+    described_class.new(repo: repo, github_client: github_client)
+  end
+
+  subject(:files) { file_fetcher_instance.files }
+  let(:url) { "https://api.github.com/repos/#{repo.name}/contents/" }
+
+  context "gemfile with path dependency" do
+    before do
+      stub_request(:get, url + "Gemfile").
+        to_return(status: 200,
+                  body: fixture(
+                    "github", "gemfile_with_path_content.json"
+                  ),
+                  headers: { "content-type" => "application/json" })
+      stub_request(:get, url + "Gemfile.lock").
+        to_return(status: 200,
+                  body: fixture(
+                    "github", "gemfile_lock_with_path_content.json"
+                  ),
+                  headers: { "content-type" => "application/json" })
+
+      stub_request(:get, url + "plugins/bump-core/bump-core.gemspec").
+        to_return(status: 200,
+                  body: fixture(
+                    "github", "gemspec_content.json"
+                  ),
+                  headers: { "content-type" => "application/json" })
+    end
+
+    it "fetches gemspec from path dependency" do
+      expect(files.map(&:name)).
+        to include("plugins/bump-core/bump-core.gemspec")
+    end
+  end
 end

--- a/spec/bump/update_checkers/ruby/bundler_spec.rb
+++ b/spec/bump/update_checkers/ruby/bundler_spec.rb
@@ -141,6 +141,25 @@ RSpec.describe Bump::UpdateCheckers::Ruby::Bundler do
             to raise_error(Bump::SharedHelpers::ChildProcessFailed)
         end
       end
+
+      context "with downloaded gemspec" do
+        let(:gemspec_body) { fixture("ruby", "bump-core_gemspec") }
+        let(:gemspec) do
+          Bump::DependencyFile.new(
+            content: gemspec_body,
+            name: "plugins/bump-core/bump-core.gemspec"
+          )
+        end
+        let(:checker) do
+          described_class.new(
+            dependency: dependency,
+            dependency_files: [gemfile, lockfile, gemspec],
+            github_access_token: "token"
+          )
+        end
+
+        it { is_expected.to eq(Gem::Version.new("1.8.0")) }
+      end
     end
 
     context "when a gem has been yanked" do

--- a/spec/fixtures/github/gemfile_lock_with_path_content.json
+++ b/spec/fixtures/github/gemfile_lock_with_path_content.json
@@ -1,0 +1,18 @@
+{
+    "name": "Gemfile.lock",
+    "path": "Gemfile.lock",
+    "sha": "edeaffa7c969c7b0e64b9777333dc7112789770b",
+    "size": 1538,
+    "url": "https://api.github.com/repos/gocardless/bump/contents/Gemfile.lock?ref=master",
+    "html_url": "https://github.com/gocardless/bump/blob/master/Gemfile.lock",
+    "git_url": "https://api.github.com/repos/gocardless/bump/git/blobs/edeaffa7c969c7b0e64b9777333dc7112789770b",
+    "download_url": "https://raw.githubusercontent.com/gocardless/bump/master/Gemfile.lock?token=ABF4KbxDYCwHdSJNkLzB_suWgDZl4os7ks5WD9kmwA%3D%3D",
+    "type": "file",
+    "content": "UEFUSAogIHJlbW90ZTogcGx1Z2lucy9idW1wLWNvcmUKICBzcGVjczoKICAgIGJ1bXAtY29yZSAoMC4xLjApCiAgICAgIHByaXVzICh+PiAzLjMuMCkKCkdFTQogIHJlbW90ZTogaHR0cHM6Ly9ydWJ5Z2Vtcy5vcmcvCiAgc3BlY3M6CiAgICBhZGRyZXNzYWJsZSAoMi4zLjgpCiAgICBhd3Mtc2RrLWNvcmUgKDIuMC40OCkKICAgICAgYnVpbGRlciAofj4gMy4wKQogICAgICBqbWVzcGF0aCAofj4gMS4wKQogICAgICBtdWx0aV9qc29uICh+PiAxLjApCiAgICBidWlsZGVyICgzLjIuMikKICAgIGNlbGx1bG9pZCAoMC4xNi4wKQogICAgICB0aW1lcnMgKH4+IDQuMC4wKQogICAgY3JhY2sgKDAuNC4yKQogICAgICBzYWZlX3lhbWwgKH4+IDEuMC4wKQogICAgZGlmZi1sY3MgKDEuMi41KQogICAgZG90ZW52ICgyLjAuMikKICAgIGZhcmFkYXkgKDAuOS4xKQogICAgICBtdWx0aXBhcnQtcG9zdCAoPj0gMS4yLCA8IDMpCiAgICBnZW1uYXNpdW0tcGFyc2VyICgwLjEuOSkKICAgIGhpdGltZXMgKDEuMi4zKQogICAgam1lc3BhdGggKDEuMS4zKQogICAgbXVsdGlfanNvbiAoMS4xMS4yKQogICAgbXVsdGlwYXJ0LXBvc3QgKDIuMC4wKQogICAgb2N0b2tpdCAoNC4xLjEpCiAgICAgIHNhd3llciAofj4gMC42LjAsID49IDAuNS4zKQogICAgcHJpdXMgKDEuMC4wKQogICAgcnNwZWMgKDMuMy4wKQogICAgICByc3BlYy1jb3JlICh+PiAzLjMuMCkKICAgICAgcnNwZWMtZXhwZWN0YXRpb25zICh+PiAzLjMuMCkKICAgICAgcnNwZWMtbW9ja3MgKH4+IDMuMy4wKQogICAgcnNwZWMtY29yZSAoMy4zLjIpCiAgICAgIHJzcGVjLXN1cHBvcnQgKH4+IDMuMy4wKQogICAgcnNwZWMtZXhwZWN0YXRpb25zICgzLjMuMSkKICAgICAgZGlmZi1sY3MgKD49IDEuMi4wLCA8IDIuMCkKICAgICAgcnNwZWMtc3VwcG9ydCAofj4gMy4zLjApCiAgICByc3BlYy1pdHMgKDEuMi4wKQogICAgICByc3BlYy1jb3JlICg+PSAzLjAuMCkKICAgICAgcnNwZWMtZXhwZWN0YXRpb25zICg+PSAzLjAuMCkKICAgIHJzcGVjLW1vY2tzICgzLjMuMikKICAgICAgZGlmZi1sY3MgKD49IDEuMi4wLCA8IDIuMCkKICAgICAgcnNwZWMtc3VwcG9ydCAofj4gMy4zLjApCiAgICByc3BlYy1zdXBwb3J0ICgzLjMuMCkKICAgIHNhZmVfeWFtbCAoMS4wLjQpCiAgICBzYXd5ZXIgKDAuNi4wKQogICAgICBhZGRyZXNzYWJsZSAofj4gMi4zLjUpCiAgICAgIGZhcmFkYXkgKH4+IDAuOCwgPCAwLjEwKQogICAgc2hvcnl1a2VuICgyLjAuMCkKICAgICAgYXdzLXNkay1jb3JlICh+PiAyLjAuMjEpCiAgICAgIGNlbGx1bG9pZCAofj4gMC4xNi4wKQogICAgdGltZXJzICg0LjAuNCkKICAgICAgaGl0aW1lcwogICAgd2VibW9jayAoMS4yMS4wKQogICAgICBhZGRyZXNzYWJsZSAoPj0gMi4zLjYpCiAgICAgIGNyYWNrICg+PSAwLjMuMikKClBMQVRGT1JNUwogIHJ1YnkKCkRFUEVOREVOQ0lFUwogIGJ1bXAtY29yZSEKICBkb3RlbnYKICBnZW1uYXNpdW0tcGFyc2VyICh+PiAwLjEuOSkKICBvY3Rva2l0ICh+PiA0LjEuMSkKICBwcml1cyAofj4gMS4wLjApCiAgcnNwZWMgKH4+IDMuMy4wKQogIHJzcGVjLWl0cyAofj4gMS4yLjApCiAgc2hvcnl1a2VuICh+PiAyLjAuMCkKICB3ZWJtb2NrICh+PiAxLjIxLjApCgpCVU5ETEVEIFdJVEgKICAgMS4xMC42Cg==",
+    "encoding": "base64",
+    "_links": {
+        "self": "https://api.github.com/repos/gocardless/bump/contents/Gemfile.lock?ref=master",
+        "git": "https://api.github.com/repos/gocardless/bump/git/blobs/edeaffa7c969c7b0e64b9777333dc7112789770b",
+        "html": "https://github.com/gocardless/bump/blob/master/Gemfile.lock"
+    }
+}

--- a/spec/fixtures/github/gemfile_with_path_content.json
+++ b/spec/fixtures/github/gemfile_with_path_content.json
@@ -1,0 +1,18 @@
+{
+    "name": "Gemfile",
+    "path": "Gemfile",
+    "sha": "dbce0c9e2e7efd19139c2c0aeb0110e837812c2f",
+    "size": 291,
+    "url": "https://api.github.com/repos/gocardless/bump/contents/Gemfile?ref=master",
+    "html_url": "https://github.com/gocardless/bump/blob/master/Gemfile",
+    "git_url": "https://api.github.com/repos/gocardless/bump/git/blobs/dbce0c9e2e7efd19139c2c0aeb0110e837812c2f",
+    "download_url": "https://raw.githubusercontent.com/gocardless/bump/master/Gemfile?token=ABF4KfGg6a7sE1n1i2rrhUvqAKRhIkPiks5WD8X5wA%3D%3D",
+    "type": "file",
+    "content": "c291cmNlICJodHRwczovL3J1YnlnZW1zLm9yZyIKCmdlbSAiYnVtcC1jb3JlIiwgcGF0aDogInBsdWdpbnMvYnVtcC1jb3JlIgo",
+    "encoding": "base64",
+    "_links": {
+        "self": "https://api.github.com/repos/gocardless/bump/contents/Gemfile?ref=master",
+        "git": "https://api.github.com/repos/gocardless/bump/git/blobs/dbce0c9e2e7efd19139c2c0aeb0110e837812c2f",
+        "html": "https://github.com/gocardless/bump/blob/master/Gemfile"
+    }
+}

--- a/spec/fixtures/github/gemspec_content.json
+++ b/spec/fixtures/github/gemspec_content.json
@@ -1,0 +1,18 @@
+{
+    "name": "bump-core.gemspec",
+    "path": "plugin/bump-core",
+    "sha": "dbce0c9e2e7efd19139c2c0aeb0110e837812c2f",
+    "size": 291,
+    "url": "https://api.github.com/repos/gocardless/bump/contents/plugin/bump-core/bump-core.gemspec?ref=master",
+    "html_url": "https://github.com/gocardless/bump/blob/master/plugin/bump-core/bump-core.gemspec",
+    "git_url": "https://api.github.com/repos/gocardless/bump/git/blobs/dbce0c9e2e7efd19139c2c0aeb0110e837812c2f",
+    "download_url": "https://raw.githubusercontent.com/gocardless/bump/master/plugin/bump-core/bump-core.gemspec?token=ABF4KfGg6a7sE1n1i2rrhUvqAKRhIkPiks5WD8X5wA%3D%3D",
+    "type": "file",
+    "content": "IyBmcm96ZW5fc3RyaW5nX2xpdGVyYWw6IHRydWUKbGliID0gRmlsZS5leHBhbmRfcGF0aCgiLi4vbGliIiwgX19GSUxFX18pCiRMT0FEX1BBVEgudW5zaGlmdChsaWIpIHVubGVzcyAkTE9BRF9QQVRILmluY2x1ZGU/KGxpYikKcmVxdWlyZSAiRW5nbGlzaCIKcmVxdWlyZSAiYnVtcC92ZXJzaW9uIgoKc3VtbWFyeSA9ICJBdXRvbWF0ZWQgZGVwZW5kZW5jeSBtYW5hZ2VtZW50IGZvciBSdWJ5LCBQeXRob24gYW5kIEphdmFzY3JpcHQiCgpHZW06OlNwZWNpZmljYXRpb24ubmV3IGRvIHxzcGVjfAogIHNwZWMubmFtZSAgICAgICAgICA9ICJidW1wLWNvcmUiCiAgc3BlYy52ZXJzaW9uICAgICAgID0gQnVtcDo6VkVSU0lPTgogIHNwZWMuYXV0aG9ycyAgICAgICA9IFsiR29DYXJkbGVzcyJdCiAgc3BlYy5lbWFpbCAgICAgICAgID0gWyJlbmdpbmVlcmluZ0Bnb2NhcmRsZXNzLmNvbSJdCiAgc3BlYy5zdW1tYXJ5ICAgICAgID0gc3VtbWFyeQogIHNwZWMuZGVzY3JpcHRpb24gICA9IHN1bW1hcnkKICBzcGVjLmhvbWVwYWdlICAgICAgPSAiaHR0cHM6Ly9naXRodWIuY29tL2dvY2FyZGxlc3MvYnVtcC1jb3JlIgogIHNwZWMubGljZW5zZXMgICAgICA9IFsiTUlUIl0KCiAgc3BlYy5maWxlcyAgICAgICAgID0gYGdpdCBscy1maWxlc2Auc3BsaXQoJElOUFVUX1JFQ09SRF9TRVBBUkFUT1IpCiAgc3BlYy5leGVjdXRhYmxlcyAgID0gc3BlYy5maWxlcy5ncmVwKCVye15iaW4vfSkgeyB8ZnwgRmlsZS5iYXNlbmFtZShmKSB9CiAgc3BlYy50ZXN0X2ZpbGVzICAgID0gc3BlYy5maWxlcy5ncmVwKCVye14odGVzdHxzcGVjfGZlYXR1cmVzKS99KQogIHNwZWMucmVxdWlyZV9wYXRocyA9IFsibGliIl0KCiAgc3BlYy5hZGRfZGVwZW5kZW5jeSAiYnVuZGxlciIsICI+PSAxLjEyLjAiCiAgc3BlYy5hZGRfZGVwZW5kZW5jeSAiZXhjb24iLCAifj4gMC41NSIKICBzcGVjLmFkZF9kZXBlbmRlbmN5ICJnZW1uYXNpdW0tcGFyc2VyIiwgIn4+IDAuMSIKICBzcGVjLmFkZF9kZXBlbmRlbmN5ICJnZW1zIiwgIn4+IDEuMCIKICBzcGVjLmFkZF9kZXBlbmRlbmN5ICJvY3Rva2l0IiwgIn4+IDQuNiIKCiAgc3BlYy5hZGRfZGV2ZWxvcG1lbnRfZGVwZW5kZW5jeSAid2VibW9jayIsICJ+PiAyLjMuMSIKICBzcGVjLmFkZF9kZXZlbG9wbWVudF9kZXBlbmRlbmN5ICJyc3BlYyIsICJ+PiAzLjUuMCIKICBzcGVjLmFkZF9kZXZlbG9wbWVudF9kZXBlbmRlbmN5ICJyc3BlYy1pdHMiLCAifj4gMS4yLjAiCiAgc3BlYy5hZGRfZGV2ZWxvcG1lbnRfZGVwZW5kZW5jeSAicnVib2NvcCIsICJ+PiAwLjQ4LjAiCiAgc3BlYy5hZGRfZGV2ZWxvcG1lbnRfZGVwZW5kZW5jeSAicmFrZSIKZW5kCg==",
+    "encoding": "base64",
+    "_links": {
+        "self": "https://api.github.com/repos/gocardless/bump/contents/plugin/bump-core/bump-core.gemspec?ref=master",
+        "git": "https://api.github.com/repos/gocardless/bump/git/blobs/dbce0c9e2e7efd19139c2c0aeb0110e837812c2f",
+        "html": "https://github.com/gocardless/bump/blob/master/plugin/bump-core/bump-core.gemspec"
+    }
+}

--- a/spec/fixtures/ruby/bump-core_gemspec
+++ b/spec/fixtures/ruby/bump-core_gemspec
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+Gem::Specification.new do |s|
+  s.name               = "bump-core"
+  s.version            = "0.0.1"
+  s.default_executable = "hola"
+
+  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
+  s.authors = ["Nick Quaranto"]
+  s.date = %q{2010-04-03}
+  s.description = %q{A simple hello world gem}
+  s.email = %q{nick@quaran.to}
+  s.files = ["Rakefile", "lib/hola.rb", "lib/hola/translator.rb", "bin/hola"]
+  s.test_files = ["test/test_hola.rb"]
+  s.homepage = %q{http://rubygems.org/gems/hola}
+  s.require_paths = ["lib"]
+  s.rubygems_version = %q{1.6.2}
+  s.summary = %q{Hola!}
+
+  if s.respond_to? :specification_version then
+    s.specification_version = 3
+
+    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
+    else
+    end
+  else
+  end
+end

--- a/spec/fixtures/ruby/gemfiles/path_source
+++ b/spec/fixtures/ruby/gemfiles/path_source
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
 source "https://rubygems.org"
 
-gem "hutch"
-gem "bump-core", path: "../bump-core"
-gem "prius", git: "https://github.com/gocardless/prius"
+gem "bump-core", path: "plugins/bump-core"
+
+gem "business", "~> 1.4.0"
+gem "statesman", "~> 1.2.0"

--- a/spec/fixtures/ruby/lockfiles/path_source.lock
+++ b/spec/fixtures/ruby/lockfiles/path_source.lock
@@ -5,7 +5,7 @@ GIT
     prius (1.0.0)
 
 PATH
-  remote: ../bump-core
+  remote: plugins/bump-core
   specs:
     bump-core (0.6.5)
       bundler (>= 1.12.0)
@@ -17,52 +17,16 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.1.2)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (~> 0.7)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
-    addressable (2.5.1)
-      public_suffix (~> 2.0, >= 2.0.2)
-    amq-protocol (2.2.0)
-    bunny (2.7.0)
-      amq-protocol (>= 2.2.0)
-    carrot-top (0.0.7)
-      json
-    concurrent-ruby (1.0.5)
-    excon (0.57.1)
-    faraday (0.12.1)
-      multipart-post (>= 1.2, < 3)
-    gemnasium-parser (0.1.9)
-    gems (1.0.0)
-      json
-    hutch (0.24.0)
-      activesupport (>= 4.2, < 6)
-      bunny (>= 2.6.3)
-      carrot-top (~> 0.0.7)
-      multi_json (~> 1.12)
-    i18n (0.8.4)
-    json (2.1.0)
-    minitest (5.10.2)
-    multi_json (1.12.1)
-    multipart-post (2.0.0)
-    octokit (4.7.0)
-      sawyer (~> 0.8.0, >= 0.5.3)
-    public_suffix (2.0.5)
-    sawyer (0.8.1)
-      addressable (>= 2.3.5, < 2.6)
-      faraday (~> 0.8, < 1.0)
-    thread_safe (0.3.6)
-    tzinfo (1.2.3)
-      thread_safe (~> 0.1)
+    business (1.4.0)
+    statesman (1.2.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   bump-core!
-  hutch
-  prius!
+  business (~> 1.4.0)
+  statesman (~> 1.2.0)
 
 BUNDLED WITH
-   1.15.0
+   1.10.6


### PR DESCRIPTION
This is a very quick fix to allow processing of Gemfiles with path
dependencies that can be resolved within the same repo.

An example that would fail in the past and work with these changes:

```
gem "somegem", path: "plugins/somegem"
```